### PR TITLE
chore: smoke published plugin inspector package

### DIFF
--- a/docs/inspector-plan.md
+++ b/docs/inspector-plan.md
@@ -93,17 +93,17 @@ npm run plugin-inspector:smoke
 ```
 
 The smoke writes ignored artifacts under `.crabpot/plugin-inspector-smoke/`.
-For local development it uses a sibling `../plugin-inspector` checkout when one
-exists. In CI or standalone checkouts it falls back to the pinned GitHub package
-source checkout. This intentionally avoids npm publishing until the package
-boundary is reviewed.
+By default the smoke runs the published `@openclaw/plugin-inspector@0.1.2`
+package through `npm exec`. For local plugin-inspector development, set
+`CRABPOT_PLUGIN_INSPECTOR_CLI=source` to run the sibling or pinned source
+checkout instead. Set `CRABPOT_PLUGIN_INSPECTOR_BIN=/path/to/plugin-inspector`
+to test an arbitrary CLI binary.
 
 Current migration state: `scripts/inspect-fixtures.mjs` delegates static source,
 manifest, and package inspection to `plugin-inspector` while preserving
-crabpot's existing command output and exported helper names. The remaining
-local scripts still own target OpenClaw comparison, issue classification,
-synthetic probes, cold-import readiness, workspace planning, runtime profiling,
-and generated crabpot report paths.
+crabpot's existing command output and exported helper names. Crabpot keeps its
+orchestration, report paths, fixture policy, and opt-in execution guards; the
+reusable compatibility logic now lives in the published inspector package.
 
 ## Compatibility issue workflow
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -119,6 +119,11 @@ npm run profile -- --check
 node scripts/check-contract-coverage.mjs --openclaw ../openclaw
 ```
 
+`npm run plugin-inspector:smoke` uses the published
+`@openclaw/plugin-inspector@0.1.2` package by default. Use
+`CRABPOT_PLUGIN_INSPECTOR_CLI=source npm run plugin-inspector:smoke` only when
+validating local inspector source changes.
+
 Issue severity means:
 
 - `P0`: current hard breakage.

--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -23,6 +23,7 @@ export function resolvePluginInspectorCliInvocation() {
     return {
       command: npmCommand(),
       args: ["exec", "--yes", "--package", pluginInspectorPackage, "--", "plugin-inspector"],
+      shell: process.platform === "win32",
     };
   }
 
@@ -120,7 +121,7 @@ function sleep(ms) {
 }
 
 function npmCommand() {
-  return process.platform === "win32" ? "npm.cmd" : "npm";
+  return "npm";
 }
 
 function readGitHead(checkoutDir) {

--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
 export const pluginInspectorRef = "0fc9697a14cd0e13550e2bfce770cff966b64ace";
+export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.1.2";
 
 export async function loadPluginInspector() {
   return import(pathToFileURL(resolvePluginInspectorSourcePath()).href);
@@ -15,6 +16,13 @@ export function resolvePluginInspectorCliInvocation() {
     return {
       command: process.env.CRABPOT_PLUGIN_INSPECTOR_BIN,
       args: [],
+    };
+  }
+
+  if (process.env.CRABPOT_PLUGIN_INSPECTOR_CLI !== "source") {
+    return {
+      command: npmCommand(),
+      args: ["exec", "--yes", "--package", pluginInspectorPackage, "--", "plugin-inspector"],
     };
   }
 
@@ -109,6 +117,10 @@ function isStaleLock(lockDir) {
 
 function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function npmCommand() {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
 }
 
 function readGitHead(checkoutDir) {

--- a/scripts/run-plugin-inspector-smoke.mjs
+++ b/scripts/run-plugin-inspector-smoke.mjs
@@ -18,6 +18,7 @@ const invocation = resolvePluginInspectorCliInvocation();
 const result = spawnSync(invocation.command, [...invocation.args, ...inspectorArgs], {
   cwd: repoRoot,
   encoding: "utf8",
+  shell: invocation.shell === true,
   stdio: "inherit",
 });
 

--- a/test/plugin-inspector-source.test.mjs
+++ b/test/plugin-inspector-source.test.mjs
@@ -10,8 +10,9 @@ test("plugin inspector smoke defaults to the published npm package", () => {
   withEnv({}, () => {
     const invocation = resolvePluginInspectorCliInvocation();
 
-    assert.match(invocation.command, /^npm(?:\.cmd)?$/);
+    assert.equal(invocation.command, "npm");
     assert.deepEqual(invocation.args, ["exec", "--yes", "--package", pluginInspectorPackage, "--", "plugin-inspector"]);
+    assert.equal(invocation.shell, process.platform === "win32");
   });
 });
 

--- a/test/plugin-inspector-source.test.mjs
+++ b/test/plugin-inspector-source.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  pluginInspectorPackage,
+  resolvePluginInspectorCliInvocation,
+  resolvePluginInspectorCliPath,
+} from "../scripts/plugin-inspector-source.mjs";
+
+test("plugin inspector smoke defaults to the published npm package", () => {
+  withEnv({}, () => {
+    const invocation = resolvePluginInspectorCliInvocation();
+
+    assert.match(invocation.command, /^npm(?:\.cmd)?$/);
+    assert.deepEqual(invocation.args, ["exec", "--yes", "--package", pluginInspectorPackage, "--", "plugin-inspector"]);
+  });
+});
+
+test("plugin inspector smoke can run local source or an explicit binary", () => {
+  withEnv({ CRABPOT_PLUGIN_INSPECTOR_CLI: "source" }, () => {
+    assert.deepEqual(resolvePluginInspectorCliInvocation(), {
+      command: process.execPath,
+      args: [resolvePluginInspectorCliPath()],
+    });
+  });
+
+  withEnv({ CRABPOT_PLUGIN_INSPECTOR_BIN: "/tmp/plugin-inspector" }, () => {
+    assert.deepEqual(resolvePluginInspectorCliInvocation(), {
+      command: "/tmp/plugin-inspector",
+      args: [],
+    });
+  });
+});
+
+function withEnv(values, callback) {
+  const keys = ["CRABPOT_PLUGIN_INSPECTOR_BIN", "CRABPOT_PLUGIN_INSPECTOR_CLI"];
+  const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  for (const key of keys) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, values);
+  try {
+    callback();
+  } finally {
+    for (const key of keys) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- run crabpot's plugin-inspector smoke through @openclaw/plugin-inspector@0.1.2 via npm exec by default
- keep local source and explicit binary overrides for inspector development
- document the published-package smoke path

## Verification
- npm run plugin-inspector:smoke
- npm test
- git diff --check