### PR TITLE
fix(ci): require lifecycle dashboard profiles

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -227,6 +227,10 @@ jobs:
           ref: ${{ steps.openclaw-track.outputs.ref }}
           path: openclaw
       - run: node scripts/sync-fixtures.mjs --materialize
+      - name: Install OpenClaw lifecycle dependencies
+        run: |
+          corepack enable
+          pnpm --dir openclaw install --frozen-lockfile --ignore-scripts
       - name: Fetch main dashboard baseline
         if: ${{ steps.openclaw-track.outputs.track != 'latest' }}
         run: |
@@ -244,7 +248,7 @@ jobs:
           node scripts/cold-import-readiness.mjs --openclaw ./openclaw
           node scripts/workspace-plan.mjs --openclaw ./openclaw
           node scripts/platform-probes.mjs --openclaw ./openclaw
-          node scripts/import-loop-profile.mjs
+          node scripts/import-loop-profile.mjs --openclaw ./openclaw --runs 3
           node scripts/profile-contract-runtime.mjs --openclaw ./openclaw --runs 3
           node scripts/compare-runtime-profile.mjs
           node scripts/check-ci-policy.mjs

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -86,6 +86,11 @@ jobs:
             exit 1
           done < /tmp/crabpot-dependabot-files.txt
 
+      - name: Install OpenClaw lifecycle dependencies
+        run: |
+          corepack enable
+          pnpm --dir openclaw install --frozen-lockfile --ignore-scripts
+
       - name: Refresh compatibility reports
         env:
           CRABPOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -102,7 +107,7 @@ jobs:
           node scripts/cold-import-readiness.mjs --openclaw ./openclaw
           node scripts/workspace-plan.mjs --openclaw ./openclaw
           node scripts/platform-probes.mjs --openclaw ./openclaw
-          node scripts/import-loop-profile.mjs
+          node scripts/import-loop-profile.mjs --openclaw ./openclaw --runs 3
           node scripts/profile-contract-runtime.mjs --openclaw ./openclaw --runs 3
           node scripts/compare-runtime-profile.mjs
           node scripts/check-ci-policy.mjs

--- a/.github/workflows/openclaw-ref-compat.yml
+++ b/.github/workflows/openclaw-ref-compat.yml
@@ -105,6 +105,10 @@ jobs:
       - name: Run runtime profile policy
         run: node scripts/compare-runtime-profile.mjs ${{ inputs.strict_perf && '--strict' || '' }}
       - run: node scripts/check-contract-coverage.mjs --openclaw ./openclaw
+      - name: Install OpenClaw lifecycle dependencies
+        run: |
+          corepack enable
+          pnpm --dir openclaw install --frozen-lockfile --ignore-scripts
 
       - name: Write report artifacts
         if: always()
@@ -117,7 +121,7 @@ jobs:
           node scripts/workspace-plan.mjs --openclaw ./openclaw
           node scripts/platform-probes.mjs --openclaw ./openclaw
           node scripts/check-generated-surface-fixture.mjs --openclaw ./openclaw
-          node scripts/import-loop-profile.mjs
+          node scripts/import-loop-profile.mjs --openclaw ./openclaw --runs "${PROFILE_RUNS}"
           node scripts/profile-contract-runtime.mjs --openclaw ./openclaw --runs "${PROFILE_RUNS}"
           node scripts/compare-runtime-profile.mjs ${{ inputs.strict_perf && '--strict' || '' }}
           node scripts/check-ci-policy.mjs ${{ inputs.strict_contract && '--strict' || '' }}

--- a/.github/workflows/track-dashboard.yml
+++ b/.github/workflows/track-dashboard.yml
@@ -82,6 +82,12 @@ jobs:
       - if: ${{ steps.select.outputs.run == 'true' }}
         run: node scripts/run-static-suite.mjs --openclaw ./openclaw --policy dashboard --profile-runs 3 --plugin-inspector-smoke
 
+      - name: Install OpenClaw lifecycle dependencies
+        if: ${{ steps.select.outputs.run == 'true' }}
+        run: |
+          corepack enable
+          pnpm --dir openclaw install --frozen-lockfile --ignore-scripts
+
       - name: Fetch main dashboard baseline
         if: ${{ steps.select.outputs.run == 'true' && matrix.track != 'latest' }}
         run: |
@@ -102,7 +108,7 @@ jobs:
           node scripts/workspace-plan.mjs --openclaw ./openclaw
           node scripts/platform-probes.mjs --openclaw ./openclaw
           node scripts/check-generated-surface-fixture.mjs --openclaw ./openclaw
-          node scripts/import-loop-profile.mjs
+          node scripts/import-loop-profile.mjs --openclaw ./openclaw --runs 3
           node scripts/profile-contract-runtime.mjs --openclaw ./openclaw --runs 3
           node scripts/compare-runtime-profile.mjs
           node scripts/check-ci-policy.mjs

--- a/scripts/import-loop-profile.mjs
+++ b/scripts/import-loop-profile.mjs
@@ -32,7 +32,9 @@ async function main() {
     openclawPath: args.openclawPath,
     runs: args.runs,
   });
-  const errors = validateImportLoopProfile(report);
+  const errors = validateImportLoopProfile(report, {
+    requireOpenClawLifecycle: Boolean(args.openclawPath),
+  });
 
   if (args.write) {
     await writeImportLoopProfile(report);
@@ -114,8 +116,12 @@ export async function buildImportLoopProfile(options = {}) {
   });
 }
 
-export function validateImportLoopProfile(report) {
-  return pluginInspector.validateImportLoopProfile(report);
+export function validateImportLoopProfile(report, options = {}) {
+  const errors = pluginInspector.validateImportLoopProfile(report);
+  if (options.requireOpenClawLifecycle && (report.summary?.openClawLifecycleCount ?? 0) < 1) {
+    errors.push("OpenClaw lifecycle profile requested but no import+activate samples were captured");
+  }
+  return errors;
 }
 
 export async function writeImportLoopProfile(report, options = {}) {

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -51,6 +51,9 @@ test("default check workflow uploads policy and summary reports", async () => {
   assert.match(workflow, /node scripts\/run-static-suite\.mjs --openclaw \.\/openclaw --policy dashboard --profile-runs 3 --plugin-inspector-smoke/);
   assert.match(workflow, /node scripts\/check-ci-policy\.mjs/);
   assert.match(workflow, /node scripts\/write-ci-summary\.mjs/);
+  const dashboardBlock = workflow.slice(workflow.indexOf("  dashboard:"));
+  assert.match(dashboardBlock, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
+  assert.match(dashboardBlock, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs 3/);
   assert.match(workflow, /--baseline-data \.crabpot\/baseline\/main-dashboard-data\.json/);
   assert.match(workflow, /node scripts\/update-readme-summary\.mjs \$\{baseline_arg\}/);
   assert.match(workflow, /chore\(readme\): update crabpot dashboard \[skip ci\]/);
@@ -84,6 +87,8 @@ test("track dashboard workflow refreshes branch dashboards by OpenClaw track", a
   assert.match(workflow, /node scripts\/resolve-openclaw-track\.mjs --track "\$\{\{ matrix\.track \}\}" --github-output/);
   assert.match(workflow, /ref: \$\{\{ steps\.openclaw-track\.outputs\.ref \}\}/);
   assert.match(workflow, /node scripts\/run-static-suite\.mjs --openclaw \.\/openclaw --policy dashboard --profile-runs 3 --plugin-inspector-smoke/);
+  assert.match(workflow, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
+  assert.match(workflow, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs 3/);
   assert.match(workflow, /node scripts\/update-track-metadata\.mjs --track "\$\{\{ matrix\.track \}\}"/);
   assert.match(workflow, /origin\/main:reports\/crabpot-dashboard-data\.json/);
   assert.match(workflow, /node scripts\/update-readme-summary\.mjs \$\{baseline_arg\}/);
@@ -154,6 +159,8 @@ test("dependabot auto-merge refreshes reports after fixture pin updates", async 
   assert.match(workflow, /node scripts\/sync-fixtures\.mjs --materialize/);
   assert.match(workflow, /node scripts\/resolve-openclaw-track\.mjs --branch "\$\{\{ github\.event\.pull_request\.base\.ref \}\}" --github-output/);
   assert.match(workflow, /node scripts\/generate-report\.mjs --openclaw \.\/openclaw/);
+  assert.match(workflow, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
+  assert.match(workflow, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs 3/);
   assert.match(workflow, /node scripts\/update-track-metadata\.mjs/);
   assert.match(workflow, /--baseline-data \.crabpot\/baseline\/main-dashboard-data\.json/);
   assert.match(workflow, /node scripts\/update-readme-summary\.mjs \$\{baseline_arg\}/);
@@ -174,6 +181,13 @@ test("manual workflow enforces strict runtime profile policy before best-effort 
     assert.doesNotMatch(step, /continue-on-error/);
   }
   assert.ok(policySteps.some((step) => step.includes("node scripts/profile-contract-runtime.mjs --openclaw ./openclaw-head")));
+});
+
+test("manual workflow writes OpenClaw lifecycle import profile artifacts", async () => {
+  const workflow = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+
+  assert.match(workflow, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
+  assert.match(workflow, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs "\$\{PROFILE_RUNS\}"/);
 });
 
 test("manual workflow keeps isolated execution artifacts and failure policy wired", async () => {

--- a/test/import-loop-profile.test.mjs
+++ b/test/import-loop-profile.test.mjs
@@ -69,3 +69,18 @@ test("import loop markdown surfaces OpenClaw lifecycle phases when present", () 
   assert.match(markdown, /OpenClaw Activate/);
   assert.match(markdown, /p50OpenClawImportMs/);
 });
+
+test("import loop validation fails requested OpenClaw lifecycle profiles without lifecycle samples", () => {
+  const errors = validateImportLoopProfile(
+    {
+      summary: {
+        openClawLifecycleCount: 0,
+      },
+    },
+    { requireOpenClawLifecycle: true },
+  );
+
+  assert.deepEqual(errors, [
+    "OpenClaw lifecycle profile requested but no import+activate samples were captured",
+  ]);
+});


### PR DESCRIPTION
## Summary
- make dashboard/report writers install OpenClaw dependencies before lifecycle profiling
- run `import-loop-profile --openclaw` for README dashboard, track dashboard, dependabot refresh, and manual ref artifacts
- fail requested OpenClaw lifecycle profiles when import+activate samples are missing instead of publishing `openClawLifecycleCount: 0`

## Validation
- `node --test test/ci-workflows.test.mjs test/run-static-suite.test.mjs test/import-loop-profile.test.mjs`
- `node scripts/import-loop-profile.mjs --check --openclaw /Users/vincentkoc/GIT/_Perso/openclaw --runs 2 --json` -> `openClawLifecycleCount: 2`
- `git diff --check`

## Note
- `npm test` is not a useful local signal in this worktree because plugin submodules are uninitialized, so fixture capture tests see zero registrations/entrypoints.
