### PR TITLE
docs(reports): add China plugin monitor candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ For deeper review, open the reports in this order:
 | Isolated install/build/capture commands Crabpot would run | `npm run workspace:plan` | `reports/crabpot-workspace-plan.md` |
 | Results from opt-in isolated fixture execution | `npm run execution:report` | `reports/crabpot-execution-results.md` |
 | Boot time and RSS against the target OpenClaw registry surface | `npm run profile` | `reports/crabpot-runtime-profile.md` |
+| China and adjacent external plugin monitor candidates | manual live discovery pass | `reports/crabpot-external-plugin-monitor.md` |
 | README dashboard refresh from all generated JSON reports | `npm run readme:summary` | `README.md`, `reports/crabpot-dashboard-data.json` |
 
 Each Markdown report has a matching JSON file beside it for CI, dashboards, and

--- a/reports/crabpot-external-plugin-monitor.json
+++ b/reports/crabpot-external-plugin-monitor.json
@@ -130,11 +130,11 @@
       "rank": "P2",
       "id": "xiaopai",
       "name": "Xiaopaitek channel",
-      "repo": "https://github.com/xiaopaitek/openclaw-xiaopai",
       "package": "@xiaopaitek/openclaw-xiaopai",
       "latestObserved": "1.0.2",
+      "sourceStatus": "npm-only; package repository metadata currently resolves to a non-public or missing GitHub repo",
       "coverageStatus": "missing",
-      "why": "Native enterprise messaging channel metadata for Xiaopaitek."
+      "why": "Native enterprise messaging channel metadata for Xiaopaitek; recheck source before promoting to a repo-backed fixture."
     },
     {
       "rank": "P2",

--- a/reports/crabpot-external-plugin-monitor.json
+++ b/reports/crabpot-external-plugin-monitor.json
@@ -1,0 +1,150 @@
+{
+  "verifiedAt": "2026-05-14",
+  "scope": "China and China-adjacent OpenClaw ecosystem plugins not already covered by Crabpot reporting",
+  "covered": [
+    {
+      "platform": "Feishu/Lark",
+      "fixture": "feishu",
+      "source": "@openclaw/feishu",
+      "note": "OpenClaw-managed monorepo package, not the separate LarkSuite official plugin"
+    },
+    {
+      "platform": "DingTalk",
+      "fixture": "ddingtalk",
+      "source": "largezhou/openclaw-dingtalk",
+      "note": "Community DingTalk channel"
+    },
+    {
+      "platform": "DingTalk",
+      "fixture": "dingtalk-connector",
+      "source": "DingTalk-Real-AI/dingtalk-openclaw-connector",
+      "note": "Official DingTalk stream connector"
+    },
+    {
+      "platform": "WeCom",
+      "fixture": "wecom",
+      "source": "sunnoy/openclaw-plugin-wecom",
+      "note": "Large community WeCom fixture"
+    },
+    {
+      "platform": "WeCom",
+      "fixture": "mocrane-wecom",
+      "source": "TencentCloud-Lighthouse/openclaw-wecom",
+      "note": "Mocrane/TencentCloud Lighthouse WeCom fixture"
+    },
+    {
+      "platform": "Weixin",
+      "fixture": "openclaw-weixin",
+      "source": "@tencent-weixin/openclaw-weixin",
+      "note": "Npm-pinned Weixin channel fixture"
+    },
+    {
+      "platform": "QQ Bot",
+      "fixture": "qqbot",
+      "source": "tencent-connect/openclaw-qqbot",
+      "note": "External repo-backed QQ Bot fixture"
+    },
+    {
+      "platform": "QQ Bot",
+      "fixture": "openclaw-qqbot",
+      "source": "@openclaw/qqbot",
+      "note": "OpenClaw-managed monorepo package"
+    },
+    {
+      "platform": "Tencent Yuanbao",
+      "fixture": "yuanbao",
+      "source": "openclaw-plugin-yuanbao",
+      "note": "Npm-pinned Tencent Yuanbao channel"
+    },
+    {
+      "platform": "TencentDB Memory",
+      "fixture": "memory-tencentdb",
+      "source": "@tencentdb-agent-memory/memory-tencentdb",
+      "note": "Npm-pinned TencentDB memory/vector-store fixture"
+    }
+  ],
+  "candidates": [
+    {
+      "rank": "P0",
+      "id": "larksuite-lark",
+      "name": "LarkSuite official Lark/Feishu",
+      "repo": "https://github.com/larksuite/openclaw-lark",
+      "package": "@larksuite/openclaw-lark",
+      "latestObserved": "2026.5.12",
+      "lastRepoUpdate": "2026-05-13T11:12:03Z",
+      "stars": 2167,
+      "coverageStatus": "missing",
+      "why": "Separate official LarkSuite artifact with heavy ecosystem usage and distinct Feishu/Lark docs/base/sheets/calendar/tasks seams."
+    },
+    {
+      "rank": "P0",
+      "id": "wecom-official",
+      "name": "WeCom official plugin",
+      "repo": "https://github.com/WecomTeam/wecom-openclaw-plugin",
+      "package": "@wecom/wecom-openclaw-plugin",
+      "latestObserved": "2026.5.7",
+      "lastRepoUpdate": "2026-05-13T22:50:20Z",
+      "stars": 412,
+      "coverageStatus": "missing",
+      "why": "Official Tencent WeCom artifact not covered by current sunnoy or mocrane WeCom fixtures."
+    },
+    {
+      "rank": "P1",
+      "id": "weibo",
+      "name": "Weibo DM channel",
+      "package": "@wecode-ai/weibo-openclaw-plugin",
+      "latestObserved": "2.2.7",
+      "lastPackageUpdate": "2026-05-13",
+      "coverageStatus": "missing",
+      "why": "Native OpenClaw channel metadata for Weibo DM, a product seam currently absent from Crabpot."
+    },
+    {
+      "rank": "P1",
+      "id": "wecom-kf",
+      "name": "WeCom Customer Service",
+      "package": "@openclaw-china/wecom-kf",
+      "latestObserved": "2026.4.24",
+      "coverageStatus": "missing",
+      "why": "Native WeCom customer-service channel, distinct from bot/app WeCom fixtures."
+    },
+    {
+      "rank": "P1",
+      "id": "wecom-app",
+      "name": "WeCom self-built app",
+      "package": "@openclaw-china/wecom-app",
+      "latestObserved": "2026.4.24",
+      "coverageStatus": "missing",
+      "why": "Native self-built enterprise app channel with proactive send behavior."
+    },
+    {
+      "rank": "P1",
+      "id": "dingtalk-doc",
+      "name": "DingTalk document MCP tools",
+      "repo": "https://github.com/suchasplus/openclaw-dingtalk-doc",
+      "package": "openclaw-dingtalk-doc",
+      "latestObserved": "0.2.5",
+      "coverageStatus": "missing",
+      "why": "DingTalk document/MCP tool surface, not another chat-channel clone."
+    },
+    {
+      "rank": "P2",
+      "id": "xiaopai",
+      "name": "Xiaopaitek channel",
+      "repo": "https://github.com/xiaopaitek/openclaw-xiaopai",
+      "package": "@xiaopaitek/openclaw-xiaopai",
+      "latestObserved": "1.0.2",
+      "coverageStatus": "missing",
+      "why": "Native enterprise messaging channel metadata for Xiaopaitek."
+    },
+    {
+      "rank": "P2",
+      "id": "tagword-group-chat",
+      "name": "Tagword group chat",
+      "repo": "https://github.com/tagword/tagword-group-chat",
+      "package": "@tagword/tagword-group-chat",
+      "latestObserved": "0.1.0",
+      "coverageStatus": "missing",
+      "why": "Feishu-first multi-agent group-chat sync with native extension metadata."
+    }
+  ]
+}

--- a/reports/crabpot-external-plugin-monitor.md
+++ b/reports/crabpot-external-plugin-monitor.md
@@ -39,7 +39,7 @@ These are active, distinct, and not currently listed in Crabpot reporting.
 | P1 | WeCom Customer Service | `@openclaw-china/wecom-kf` | npm `2026.4.24` | Native OpenClaw channel for WeCom customer-service conversations. Distinct from bot/app WeCom channels. |
 | P1 | WeCom self-built app | `@openclaw-china/wecom-app` | npm `2026.4.24` | Native OpenClaw channel for self-built enterprise apps and proactive sending. Distinct from intelligent-bot WeCom channels. |
 | P1 | DingTalk document MCP tools | `suchasplus/openclaw-dingtalk-doc`, `openclaw-dingtalk-doc` | npm `0.2.5`, repo-backed | DingTalk document/MCP tool surface, not another chat-channel clone. Adds a document-tool seam under the DingTalk platform. |
-| P2 | Xiaopaitek channel | `xiaopaitek/openclaw-xiaopai`, `@xiaopaitek/openclaw-xiaopai` | npm `1.0.2`, published 2026-05-07 | Native channel catalog metadata for Xiaopaitek enterprise messaging. Monitor if we want broader China enterprise messaging coverage. |
+| P2 | Xiaopaitek channel | `@xiaopaitek/openclaw-xiaopai` (npm-only; repo metadata currently 404s) | npm `1.0.2`, published 2026-05-07 | Native channel catalog metadata for Xiaopaitek enterprise messaging. Monitor if we want broader China enterprise messaging coverage, but recheck source before promoting to a repo-backed fixture. |
 | P2 | Tagword group chat | `tagword/tagword-group-chat`, `@tagword/tagword-group-chat` | npm `0.1.0`, published 2026-04-12 | Feishu-first multi-agent group-chat sync with native extension metadata. Good later fixture for multi-agent/session persistence. |
 
 ## Defer

--- a/reports/crabpot-external-plugin-monitor.md
+++ b/reports/crabpot-external-plugin-monitor.md
@@ -1,0 +1,83 @@
+# Crabpot External Plugin Monitor Candidates
+
+Verified: 2026-05-14
+
+Scope: China and China-adjacent OpenClaw ecosystem plugins that are not already
+covered by Crabpot reporting, plus the existing covered fixtures that prove the
+same platform seams.
+
+Selection rule: prioritize active repo-backed or npm-published native OpenClaw
+plugins with a distinct seam. Popular forks, setup guides, and CLI-only helpers
+belong below native plugins unless they expose an OpenClaw extension entry.
+
+## Current Coverage
+
+These are already in `crabpot.config.json` and present in the generated report.
+
+| Platform | Covered fixture | Upstream | Coverage note |
+| --- | --- | --- | --- |
+| Feishu/Lark | `feishu` | `@openclaw/feishu` | OpenClaw-managed monorepo package. Does not cover the separate LarkSuite official plugin. |
+| DingTalk | `ddingtalk` | `largezhou/openclaw-dingtalk` | Community DingTalk channel. |
+| DingTalk | `dingtalk-connector` | `DingTalk-Real-AI/dingtalk-openclaw-connector` | Official DingTalk stream connector. |
+| WeCom | `wecom` | `sunnoy/openclaw-plugin-wecom` | Large community WeCom fixture. |
+| WeCom | `mocrane-wecom` | `TencentCloud-Lighthouse/openclaw-wecom` | Mocrane/TencentCloud Lighthouse WeCom fixture. |
+| Weixin | `openclaw-weixin` | `@tencent-weixin/openclaw-weixin` | Npm-pinned Weixin channel fixture. |
+| QQ Bot | `qqbot` | `tencent-connect/openclaw-qqbot` | External repo-backed QQ Bot fixture. |
+| QQ Bot | `openclaw-qqbot` | `@openclaw/qqbot` | OpenClaw-managed monorepo package. |
+| Tencent Yuanbao | `yuanbao` | `openclaw-plugin-yuanbao` | Npm-pinned Tencent Yuanbao channel. |
+| TencentDB Memory | `memory-tencentdb` | `@tencentdb-agent-memory/memory-tencentdb` | Npm-pinned TencentDB memory/vector-store fixture. |
+
+## Add Next
+
+These are active, distinct, and not currently listed in Crabpot reporting.
+
+| Rank | Candidate | Source | Latest observed | Why monitor |
+| --- | --- | --- | --- | --- |
+| P0 | LarkSuite official Lark/Feishu | `larksuite/openclaw-lark`, `@larksuite/openclaw-lark` | GitHub updated 2026-05-13; npm `2026.5.12` | Biggest missed external plugin. It is a separate official LarkSuite artifact, not the current `@openclaw/feishu` fixture. Covers messaging plus docs/base/sheets/calendar/tasks and has a large live issue surface. |
+| P0 | WeCom official plugin | `WecomTeam/wecom-openclaw-plugin`, `@wecom/wecom-openclaw-plugin` | GitHub updated 2026-05-13; npm `2026.5.7` | Separate official Tencent WeCom artifact. Current Crabpot covers `sunnoy` and `mocrane`, but not this official package or its richer WeCom workflow seams. |
+| P1 | Weibo DM channel | `@wecode-ai/weibo-openclaw-plugin` | npm `2.2.7`, published 2026-05-13 | Npm metadata exposes native OpenClaw extensions and channel catalog metadata. No current Weibo fixture exists. |
+| P1 | WeCom Customer Service | `@openclaw-china/wecom-kf` | npm `2026.4.24` | Native OpenClaw channel for WeCom customer-service conversations. Distinct from bot/app WeCom channels. |
+| P1 | WeCom self-built app | `@openclaw-china/wecom-app` | npm `2026.4.24` | Native OpenClaw channel for self-built enterprise apps and proactive sending. Distinct from intelligent-bot WeCom channels. |
+| P1 | DingTalk document MCP tools | `suchasplus/openclaw-dingtalk-doc`, `openclaw-dingtalk-doc` | npm `0.2.5`, repo-backed | DingTalk document/MCP tool surface, not another chat-channel clone. Adds a document-tool seam under the DingTalk platform. |
+| P2 | Xiaopaitek channel | `xiaopaitek/openclaw-xiaopai`, `@xiaopaitek/openclaw-xiaopai` | npm `1.0.2`, published 2026-05-07 | Native channel catalog metadata for Xiaopaitek enterprise messaging. Monitor if we want broader China enterprise messaging coverage. |
+| P2 | Tagword group chat | `tagword/tagword-group-chat`, `@tagword/tagword-group-chat` | npm `0.1.0`, published 2026-04-12 | Feishu-first multi-agent group-chat sync with native extension metadata. Good later fixture for multi-agent/session persistence. |
+
+## Defer
+
+These showed up in live search, but should not become Crabpot fixtures yet.
+
+| Candidate | Reason |
+| --- | --- |
+| `AlexAnys/openclaw-feishu`, `Futaoj/enable_openclaw_feishu_lark`, and similar Feishu setup repos | High visibility, but they look like guides, bridges, or setup kits rather than native OpenClaw plugin artifacts. Useful for user-support signal, not fixture coverage. |
+| Feishu/Lark fork packages such as `@brycehuang/openclaw-lark`, `@realguan/openclaw-lark`, `ylib-openclaw-lark` | Mostly forks or republished variants of the LarkSuite artifact. Track only if they diverge into a distinct runtime seam. |
+| DingTalk fork packages such as `@soimy/dingtalk`, `@nextclaw/channel-plugin-dingtalk`, `clawdbot-dingtalk` | Covered better by the official connector plus one mature community DingTalk channel unless a fork introduces a unique seam. |
+| `@looki-ai/openclaw-looki-cli`, `@long_88/openclaw-aicc-channel-cli` | CLI installer packages only in npm metadata. Need the underlying native plugin package or repo before fixture inclusion. |
+| `openclaw-lark-multi-agent` | Interesting and active, but npm metadata only exposed keywords in the quick pass. Verify package contents before promoting. |
+
+## Reporting Gaps
+
+- Crabpot currently reports 57 fixtures, but none of the P0/P1 candidates above
+  appear by package name or source repo in `crabpot.config.json`.
+- The most important false sense of coverage is Feishu/Lark: `feishu` covers the
+  OpenClaw-managed `@openclaw/feishu`, while the ecosystem-heavy package is
+  `@larksuite/openclaw-lark`.
+- The second false sense of coverage is WeCom: existing fixtures cover community
+  and Mocrane paths, but not the official `WecomTeam/wecom-openclaw-plugin`
+  package.
+- Weibo, WeCom KF, WeCom App, DingTalk document tools, and Xiaopaitek add
+  genuinely new product seams rather than one more same-shaped channel plugin.
+
+## Suggested Fixture Batch
+
+Small first batch:
+
+1. Add `larksuite-lark` as a repo-backed high-priority fixture.
+2. Add `wecom-official` as a repo-backed high-priority fixture.
+3. Add `weibo` as an npm-pinned high-priority fixture.
+
+Second batch:
+
+1. Add `wecom-kf` and `wecom-app` as npm-pinned high-priority fixtures.
+2. Add `dingtalk-doc` as a repo-backed medium-priority fixture.
+3. Recheck Xiaopaitek and Tagword package contents, then decide if they earn
+   medium-priority fixtures.


### PR DESCRIPTION
## Summary
- add a persistent China and adjacent OpenClaw external plugin monitor report
- add a JSON twin for future dashboard/script consumption
- link the monitor report from the README report index

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('reports/crabpot-external-plugin-monitor.json','utf8')); console.log('external plugin monitor json ok')"`
- `git diff --check`
- `node --test test/submodules-docs.test.mjs test/readme-summary.test.mjs`
