### PR TITLE
fix(runtime): execute synthetic probes through inspector

### DIFF
--- a/crabpot.config.json
+++ b/crabpot.config.json
@@ -997,6 +997,22 @@
           "registerTool"
         ]
       },
+      "execution": {
+        "blockedFailures": [
+          {
+            "id": "memory-lancedb-tool-query-input",
+            "seam": "registerTool",
+            "errorIncludes": "reading 'replace'",
+            "reason": "captured memory tool requires realistic query/text input"
+          },
+          {
+            "id": "memory-lancedb-host-embedding-runtime",
+            "seam": "registerTool",
+            "errorIncludes": "memory-core-host-engine-embeddings",
+            "reason": "captured memory tool requires the host embedding provider runtime"
+          }
+        ]
+      },
       "why": "Official LanceDB memory package covering automatic recall/capture hooks, vector-store lifecycle, service/CLI setup, tool contracts, and npm artifact packaging."
     },
     {

--- a/scripts/execute-workspace-plan.mjs
+++ b/scripts/execute-workspace-plan.mjs
@@ -156,6 +156,9 @@ export function selectWorkspaceSteps(plan, args) {
       if (args.entrypoint && entrypoint.id !== args.entrypoint) {
         continue;
       }
+      if (!args.dryRun && !args.entrypoint && entrypoint.status === "missing") {
+        continue;
+      }
       selected.push({
         fixture: fixture.id,
         entrypoint: entrypoint.id,

--- a/scripts/synthetic-probes.mjs
+++ b/scripts/synthetic-probes.mjs
@@ -5,7 +5,6 @@ import { pathToFileURL } from "node:url";
 import { readConfiguredManifest, repoRoot } from "./manifest-lib.mjs";
 import { buildReport } from "./report-lib.mjs";
 import { loadPluginInspectorPublicApi } from "./plugin-inspector-source.mjs";
-import { captureEntrypoint } from "./run-cold-import-capture.mjs";
 
 export const defaultSyntheticProbeJsonPath = path.join(repoRoot, "reports/crabpot-synthetic-probes.json");
 export const defaultSyntheticProbeMarkdownPath = path.join(repoRoot, "reports/crabpot-synthetic-probes.md");
@@ -25,13 +24,11 @@ async function main() {
     if (process.env.CRABPOT_EXECUTE_ISOLATED !== "1") {
       throw new Error("synthetic probe execution requires CRABPOT_EXECUTE_ISOLATED=1");
     }
-    const capture = await captureEntrypoint(args.entrypoint, {
-      apiOptions: { retainHandlers: true },
+    const result = await runEntrypointSyntheticProbes(args.entrypoint, {
       cwd: args.cwd,
       mockSdk: args.mockSdk,
       pluginRoot: args.pluginRoot,
     });
-    const result = await runCapturedSyntheticProbes(capture);
     await writeJsonResult(result, args.output);
     if (result.summary.failCount > 0) {
       throw new Error(`${result.summary.failCount} synthetic probes failed`);
@@ -144,6 +141,31 @@ export async function writeSyntheticProbePlan(plan, options = {}) {
 export async function runCapturedSyntheticProbes(capture, options = {}) {
   const result = await pluginInspector.runCapturedSyntheticProbes(capture, {
     ...options,
+    syntheticSource: "crabpot.synthetic",
+  });
+  const manifest = options.manifest ?? (await readConfiguredManifest());
+  return applyFixtureSyntheticFailurePolicy(result, manifest);
+}
+
+export async function runEntrypointSyntheticProbes(entrypoint, options = {}) {
+  if (typeof pluginInspector.runEntrypointSyntheticProbes !== "function") {
+    const { captureEntrypoint } = await import("./run-cold-import-capture.mjs");
+    const capture = await captureEntrypoint(entrypoint, {
+      ...options,
+      apiOptions: {
+        ...(options.apiOptions ?? {}),
+        retainHandlers: true,
+      },
+    });
+    return runCapturedSyntheticProbes(capture, options);
+  }
+
+  const result = await pluginInspector.runEntrypointSyntheticProbes(entrypoint, {
+    ...options,
+    apiOptions: {
+      ...(options.apiOptions ?? {}),
+      retainHandlers: true,
+    },
     syntheticSource: "crabpot.synthetic",
   });
   const manifest = options.manifest ?? (await readConfiguredManifest());

--- a/test/execute-workspace-plan.test.mjs
+++ b/test/execute-workspace-plan.test.mjs
@@ -79,6 +79,46 @@ test("workspace executor can narrow to one entrypoint inside a fixture", () => {
   );
 });
 
+test("workspace executor skips missing entrypoints unless explicitly selected", () => {
+  const plan = {
+    fixtures: [
+      {
+        id: "memory-lancedb",
+        entrypoints: [
+          {
+            id: "cold-import.extension:memory-lancedb:index",
+            packagePath: "plugins/memory-lancedb/.crabpot-package/package.json",
+            status: "missing",
+            steps: [{ kind: "capture", command: "node missing.js", cwd: ".", reason: "capture" }],
+          },
+          {
+            id: "cold-import.runtimeExtension:memory-lancedb:dist-index",
+            packagePath: "plugins/memory-lancedb/.crabpot-package/package.json",
+            status: "dependency-install-required",
+            steps: [{ kind: "capture", command: "node dist.js", cwd: ".", reason: "capture" }],
+          },
+        ],
+      },
+    ],
+  };
+
+  assert.deepEqual(
+    selectWorkspaceSteps(plan, { fixture: "memory-lancedb" }).map((item) => item.entrypoint),
+    ["cold-import.runtimeExtension:memory-lancedb:dist-index"],
+  );
+  assert.deepEqual(
+    selectWorkspaceSteps(plan, { dryRun: true, fixture: "memory-lancedb" }).map((item) => item.entrypoint),
+    ["cold-import.extension:memory-lancedb:index", "cold-import.runtimeExtension:memory-lancedb:dist-index"],
+  );
+  assert.deepEqual(
+    selectWorkspaceSteps(plan, {
+      fixture: "memory-lancedb",
+      entrypoint: "cold-import.extension:memory-lancedb:index",
+    }).map((item) => item.entrypoint),
+    ["cold-import.extension:memory-lancedb:index"],
+  );
+});
+
 test("workspace executor can select an explicit fixture set", () => {
   const plan = {
     fixtures: [


### PR DESCRIPTION
## Summary

- Problem: beta fixture probes reported P1s for `memory-lancedb` and `openclaw-telemetry` because Crabpot still executed synthetic probes through the older capture/rehydration path.
- What changed: route Crabpot synthetic fixture execution through `plugin-inspector`'s entrypoint runner when available, skip missing package-source entrypoints during live execution, and classify the known `memory-lancedb` tool runtime blockers explicitly.
- What this does not cover: this does not publish or pin a new `plugin-inspector` package. Until openclaw/plugin-inspector#21 is released/pinned, the fixture proof uses `CRABPOT_PLUGIN_INSPECTOR_DIR` pointed at that branch.

## Fixture impact

- [x] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [x] Changes contract/smoke logic
- [ ] Docs only

## Verification

- [ ] `npm test` - local full run is blocked by fresh worktree fixture/submodule materialization drift unrelated to this patch
- [x] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [x] strict fixture smoke, if submodules were materialized

Targeted checks run:

- `node --test test/execute-workspace-plan.test.mjs test/synthetic-probes.test.mjs test/manifest.test.mjs` passed: 23/23
- `CRABPOT_PLUGIN_INSPECTOR_DIR=/Users/REDACTED/.codex/worktrees/openclaw-plugin-inspector/fix-mock-sdk-synthetic-probes CRABPOT_PLUGIN_TRACK=beta CRABPOT_EXECUTE_ISOLATED=1 node scripts/execute-workspace-plan.mjs --fixture openclaw-telemetry --openclaw /Users/REDACTED/GIT/_Perso/openclaw --continue-on-error` passed: 6 pass, 0 fail, 1 blocked lifecycle probe
- `CRABPOT_PLUGIN_INSPECTOR_DIR=/Users/REDACTED/.codex/worktrees/openclaw-plugin-inspector/fix-mock-sdk-synthetic-probes CRABPOT_PLUGIN_TRACK=beta CRABPOT_EXECUTE_ISOLATED=1 node scripts/execute-workspace-plan.mjs --fixture memory-lancedb --openclaw /Users/REDACTED/GIT/_Perso/openclaw --continue-on-error` passed: 4 pass, 0 fail, 4 blocked known non-target runtime probes

## Notes

No external services, secrets, or live plugin credentials were used. The two beta P1 hook findings are harness/package-inspector issues, not upstream plugin regressions.
