### PR TITLE
fix(ci): protect track dashboard refreshes

### DIFF
--- a/.github/workflows/track-dashboard.yml
+++ b/.github/workflows/track-dashboard.yml
@@ -27,7 +27,7 @@ jobs:
     name: Refresh ${{ matrix.track }} dashboard
     runs-on: ubuntu-latest
     concurrency:
-      group: crabpot-track-dashboard-${{ matrix.track }}
+      group: crabpot-track-dashboard-${{ github.event_name == 'workflow_dispatch' && 'manual' || 'schedule' }}-${{ github.event_name == 'workflow_dispatch' && inputs.track == 'all' && matrix.track || inputs.track || matrix.track }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -118,15 +118,18 @@ jobs:
           CRABPOT_PLUGIN_TRACK: ${{ matrix.plugin_track }}
           CRABPOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          export CRABPOT_SUMMARY_GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          CRABPOT_SUMMARY_GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          export CRABPOT_SUMMARY_GENERATED_AT
+          rm -rf reports
+          mkdir -p reports
           execution_fixture_set="${{ matrix.fixture_set }}"
           if [ -z "${execution_fixture_set}" ]; then
             execution_fixture_set="all"
           fi
           CRABPOT_EXECUTE_ISOLATED=1 node scripts/execute-workspace-plan.mjs --fixture-set "${execution_fixture_set}" --openclaw ./openclaw --continue-on-error
           node scripts/summarize-execution-results.mjs --write
-          execution_results_arg="--execution-results reports/crabpot-execution-results.json"
-          node scripts/generate-report.mjs --openclaw ./openclaw ${execution_results_arg}
+          execution_results_args=(--execution-results reports/crabpot-execution-results.json)
+          node scripts/generate-report.mjs --openclaw ./openclaw "${execution_results_args[@]}"
           node scripts/capture-contracts.mjs --openclaw ./openclaw
           node scripts/synthetic-probes.mjs --openclaw ./openclaw
           node scripts/cold-import-readiness.mjs --openclaw ./openclaw
@@ -139,11 +142,11 @@ jobs:
           node scripts/check-ci-policy.mjs
           node scripts/write-ci-summary.mjs --mode "track:${{ matrix.track }}" --openclaw-label "${{ steps.openclaw-track.outputs.label }}"
           node scripts/update-track-metadata.mjs --track "${{ matrix.track }}"
-          baseline_arg=""
+          baseline_args=()
           if [ -f .crabpot/baseline/main-dashboard-data.json ]; then
-            baseline_arg="--baseline-data .crabpot/baseline/main-dashboard-data.json"
+            baseline_args=(--baseline-data .crabpot/baseline/main-dashboard-data.json)
           fi
-          node scripts/update-readme-summary.mjs ${baseline_arg}
+          node scripts/update-readme-summary.mjs "${baseline_args[@]}"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -159,7 +162,7 @@ jobs:
           fi
 
       - name: Upload track reports
-        if: ${{ always() && steps.select.outputs.run == 'true' }}
+        if: ${{ always() && !cancelled() && steps.select.outputs.run == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: crabpot-track-${{ matrix.track }}-reports

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -78,6 +78,8 @@ test("track dashboard workflow refreshes branch dashboards by OpenClaw track", a
 
   assert.match(workflow, /schedule:/);
   assert.match(workflow, /cron: "7,22,37,52 \* \* \* \*"/);
+  assert.match(workflow, /crabpot-track-dashboard-\$\{\{ github\.event_name == 'workflow_dispatch' && 'manual' \|\| 'schedule' \}\}-/);
+  assert.match(workflow, /github\.event_name == 'workflow_dispatch' && inputs\.track == 'all' && matrix\.track \|\| inputs\.track \|\| matrix\.track/);
   assert.match(workflow, /cancel-in-progress: true/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /track:/);
@@ -96,15 +98,19 @@ test("track dashboard workflow refreshes branch dashboards by OpenClaw track", a
   assert.match(workflow, /corepack prepare "\$\(node -p "require\('\.\/openclaw\/package\.json'\)\.packageManager\.split\('\+'\)\[0\]"\)" --activate/);
   assert.match(workflow, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
   assert.match(workflow, /execution_fixture_set="all"/);
+  assert.match(workflow, /rm -rf reports[\s\S]*mkdir -p reports[\s\S]*execution_fixture_set/);
   assert.match(workflow, /node scripts\/execute-workspace-plan\.mjs --fixture-set "\$\{execution_fixture_set\}" --openclaw \.\/openclaw --continue-on-error/);
   assert.match(workflow, /node scripts\/summarize-execution-results\.mjs --write/);
-  assert.match(workflow, /node scripts\/generate-report\.mjs --openclaw \.\/openclaw \$\{execution_results_arg\}/);
+  assert.match(workflow, /execution_results_args=\(--execution-results reports\/crabpot-execution-results\.json\)/);
+  assert.match(workflow, /node scripts\/generate-report\.mjs --openclaw \.\/openclaw "\$\{execution_results_args\[@\]\}"/);
   assert.match(workflow, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs 3/);
   assert.match(workflow, /node scripts\/update-track-metadata\.mjs --track "\$\{\{ matrix\.track \}\}"/);
   assert.match(workflow, /origin\/main:reports\/crabpot-dashboard-data\.json/);
-  assert.match(workflow, /node scripts\/update-readme-summary\.mjs \$\{baseline_arg\}/);
+  assert.match(workflow, /baseline_args=\(\)/);
+  assert.match(workflow, /node scripts\/update-readme-summary\.mjs "\$\{baseline_args\[@\]\}"/);
   assert.match(workflow, /git push origin HEAD:\$\{\{ matrix\.branch \}\}/);
   assert.match(workflow, /git push --force-with-lease="refs\/heads\/\$\{\{ matrix\.branch \}\}" origin HEAD:\$\{\{ matrix\.branch \}\}/);
+  assert.match(workflow, /always\(\) && !cancelled\(\) && steps\.select\.outputs\.run == 'true'/);
 });
 
 test("default check workflow runs OS and container static lanes", async () => {


### PR DESCRIPTION
## Summary

- Problem: scheduled development refreshes can cancel a manual `all` refresh because skipped beta/latest matrix jobs still enter the same per-track concurrency groups.
- What changed: split dashboard concurrency by schedule/manual source, clear `reports/` before branch writes, skip cancelled artifact uploads, and quote dashboard shell args cleanly.
- What this does not cover: upstream plugin runtime/build failures surfaced by completed dashboard captures.

## Fixture impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [ ] Changes contract/smoke logic
- [ ] Docs only

## Verification

- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] strict fixture smoke, if submodules were materialized
- [x] `actionlint .github/workflows/track-dashboard.yml`
- [x] `node --test test/ci-workflows.test.mjs test/run-static-suite.test.mjs`
- [x] `git diff --check`

## Notes

`npm test` / full `node --test test/*.test.mjs` was intentionally not used as the handoff gate in this fresh worktree because plugin submodules are not materialized locally; targeted workflow tests cover this patch.
