### PR TITLE
fix: pin plugin inspector source smoke

### DIFF
--- a/docs/inspector-plan.md
+++ b/docs/inspector-plan.md
@@ -93,7 +93,7 @@ npm run plugin-inspector:smoke
 ```
 
 The smoke writes ignored artifacts under `.crabpot/plugin-inspector-smoke/`.
-By default the smoke runs the published `@openclaw/plugin-inspector@0.1.3`
+By default the smoke runs the published `@openclaw/plugin-inspector@0.3.11`
 package through `npm exec`. For local plugin-inspector development, set
 `CRABPOT_PLUGIN_INSPECTOR_CLI=source` to run the sibling or pinned source
 checkout instead. Set `CRABPOT_PLUGIN_INSPECTOR_BIN=/path/to/plugin-inspector`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -120,7 +120,7 @@ node scripts/check-contract-coverage.mjs --openclaw ../openclaw
 ```
 
 `npm run plugin-inspector:smoke` uses the published
-`@openclaw/plugin-inspector@0.1.3` package by default. Use
+`@openclaw/plugin-inspector@0.3.11` package by default. Use
 `CRABPOT_PLUGIN_INSPECTOR_CLI=source npm run plugin-inspector:smoke` only when
 validating local inspector source changes.
 

--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
-export const pluginInspectorRef = "d1a09d76c4d7c0c618aeff8f431074ab3fb9d2c1";
+export const pluginInspectorRef = "8a10c5096f6b2752b4ef3511b66f4d64f92f7cc7";
 export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.11";
 
 export async function loadPluginInspector() {


### PR DESCRIPTION
Summary
- Pin Crabpot source-mode plugin-inspector checks to the merged mock SDK fixes.
- Correct plugin-inspector smoke docs to the current 0.3.11 package pin.

Verification
- CRABPOT_PLUGIN_INSPECTOR_CLI=source npx -y -p node@22 node scripts/run-static-suite.mjs --openclaw /Users/m1/.codex/worktrees/openclaw-openclaw/fix-codex-app-server-agent-dir --policy dashboard --profile-runs 3 --plugin-inspector-smoke --openclaw-track development --fixture-set openclaw-beta --plugin-track source-pack
- CRABPOT_EXECUTE_ISOLATED=1 source-mode openclaw-beta workspace execution + summary/report/synthetic/policy: 68 pass, 0 fail, 13 blocked; policy pass
- /Users/m1/GIT/_Perso/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local
