### PR TITLE
fix(synthetic): classify transcript source providers

### DIFF
--- a/scripts/synthetic-probes.mjs
+++ b/scripts/synthetic-probes.mjs
@@ -12,6 +12,12 @@ export const defaultSyntheticProbeMarkdownPath = path.join(repoRoot, "reports/cr
 const pluginInspector = await loadPluginInspectorPublicApi();
 
 const httpRouteDescriptorInputReason = "captured HTTP route probe requires route descriptor input";
+const crabpotMetadataOnlyRegistrars = new Map([
+  [
+    "registerTranscriptSourceProvider",
+    "transcript source providers are captured as registration metadata before transcript provider runtime execution",
+  ],
+]);
 
 export function validateSyntheticProbePlan(plan) {
   return pluginInspector
@@ -273,6 +279,21 @@ function applyCrabpotSyntheticProbePlanPolicy(plan) {
 
   let changed = false;
   const probes = plan.probes.map((probe) => {
+    const metadataOnlyReason = crabpotMetadataOnlyRegistrars.get(probe.seam);
+    if (probe.kind === "registration" && probe.status === "blocked" && metadataOnlyReason) {
+      changed = true;
+      return {
+        ...probe,
+        status: "ready",
+        blocker: null,
+        execution: {
+          mode: "metadata-only",
+          callableProperties: [],
+          reason: metadataOnlyReason,
+        },
+      };
+    }
+
     if (probe.kind !== "registration" || probe.seam !== "registerHttpRoute" || probe.status !== "ready") {
       return probe;
     }

--- a/test/synthetic-probes.test.mjs
+++ b/test/synthetic-probes.test.mjs
@@ -57,6 +57,37 @@ test("synthetic probe plan marks HTTP routes blocked until descriptor inputs exi
   assert.equal(plan.probes[0].blocker, "captured HTTP route probe requires route descriptor input");
 });
 
+test("synthetic probe plan treats transcript source providers as metadata-only", async () => {
+  const plan = await buildSyntheticProbePlan({
+    capture: {
+      generatedAt: "deterministic",
+      summary: { fixtureCount: 1 },
+      fixtures: [
+        {
+          id: "fixture",
+          hooks: [],
+          registrations: [
+            {
+              id: "registration.registerTranscriptSourceProvider:fixture",
+              registrar: "registerTranscriptSourceProvider",
+              assertions: ["registration arguments are captured"],
+              syntheticArguments: [{ id: "fixture-transcript-source" }],
+              ref: "fixture.js:1",
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(validateSyntheticProbePlan(plan), []);
+  assert.equal(plan.summary.readyCount, 1);
+  assert.equal(plan.summary.blockedCount, 0);
+  assert.equal(plan.summary.metadataOnlyCount, 1);
+  assert.equal(plan.probes[0].status, "ready");
+  assert.equal(plan.probes[0].execution.mode, "metadata-only");
+});
+
 test("synthetic probe CLI refuses isolated execution without opt-in", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "crabpot-probes-"));
   const entrypoint = path.join(dir, "fixture.mjs");


### PR DESCRIPTION
## Summary

- Problem: beta dashboard hydration fails because `registerTranscriptSourceProvider` is captured but not classified for synthetic execution.
- What changed: classify transcript source provider registrations as metadata-only synthetic probes, matching provider descriptor surfaces that are captured before runtime execution.
- What this does not cover: no fixture manifest or submodule pin changes.

## Fixture impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [x] Changes contract/smoke logic
- [ ] Docs only

## Verification

- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] strict fixture smoke, if submodules were materialized
- [x] `node --test --test-name-pattern "transcript source providers" test/synthetic-probes.test.mjs`

## Notes

Full `node --test test/synthetic-probes.test.mjs` was not used as proof because this fresh Codex worktree has no materialized capture data; the pre-existing current-capture assertion sees an empty probe set. GitHub dashboard rerun is the decisive proof after landing.
