### PR TITLE
fix(dashboard): bound isolated workspace execution

### DIFF
--- a/.github/workflows/track-dashboard.yml
+++ b/.github/workflows/track-dashboard.yml
@@ -117,6 +117,7 @@ jobs:
           CRABPOT_OPENCLAW_TRACK: ${{ matrix.track }}
           CRABPOT_PLUGIN_TRACK: ${{ matrix.plugin_track }}
           CRABPOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CRABPOT_WORKSPACE_STEP_TIMEOUT_MS: "300000"
         run: |
           CRABPOT_SUMMARY_GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           export CRABPOT_SUMMARY_GENERATED_AT

--- a/scripts/execute-workspace-plan.mjs
+++ b/scripts/execute-workspace-plan.mjs
@@ -319,6 +319,10 @@ async function measureLocalStep(step, callback) {
 function measureProcessStep(step, operation) {
   return new Promise((resolve, reject) => {
     const start = performance.now();
+    const timeoutMs = readWorkspaceStepTimeoutMs();
+    let timedOut = false;
+    let forceKillTimer;
+    let terminateTimer;
     let peakRssKb = 0;
     let peakCpuPercent = 0;
     const cpuSamples = [];
@@ -329,10 +333,18 @@ function measureProcessStep(step, operation) {
     mkdirSync(env.OPENCLAW_HOME, { recursive: true });
     const child = spawn(portableCommand(operation.command), operation.args, {
       cwd: path.join(repoRoot, step.cwd),
+      detached: process.platform !== "win32",
       env,
       shell: false,
       stdio: operation.captureStdoutPath ? ["ignore", "pipe", "inherit"] : "inherit",
     });
+    if (timeoutMs > 0) {
+      terminateTimer = setTimeout(() => {
+        timedOut = true;
+        forceKillTimer = terminateProcessGroup(child);
+      }, timeoutMs);
+      terminateTimer.unref?.();
+    }
     const stdoutChunks = [];
     if (operation.captureStdoutPath) {
       child.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
@@ -357,6 +369,8 @@ function measureProcessStep(step, operation) {
     }, 100);
     child.on("exit", async (code) => {
       clearInterval(poll);
+      clearTimeout(terminateTimer);
+      clearTimeout(forceKillTimer);
       const finalStats = await readProcessStats(child.pid);
       peakRssKb = Math.max(peakRssKb, finalStats.rssKb);
       peakCpuPercent = Math.max(peakCpuPercent, finalStats.cpuPercent);
@@ -372,7 +386,7 @@ function measureProcessStep(step, operation) {
         await mkdir(path.dirname(operation.captureStdoutPath), { recursive: true });
         await writeFile(operation.captureStdoutPath, Buffer.concat(stdoutChunks));
       }
-      const exitCode = code ?? 1;
+      const exitCode = timedOut ? 124 : code ?? 1;
       resolve({
         kind: step.kind,
         command: step.command,
@@ -380,6 +394,8 @@ function measureProcessStep(step, operation) {
         artifactPath: step.artifactPath ?? null,
         exitCode: operation.ignoreExitCode ? 0 : exitCode,
         rawExitCode: operation.ignoreExitCode ? exitCode : undefined,
+        timeoutMs: timeoutMs > 0 ? timeoutMs : undefined,
+        timedOut,
         wallMs,
         peakRssMb: Math.round((peakRssKb / 1024) * 10) / 10,
         peakCpuPercent: Math.round(peakCpuPercent * 10) / 10,
@@ -388,9 +404,51 @@ function measureProcessStep(step, operation) {
     });
     child.on("error", (error) => {
       clearInterval(poll);
+      clearTimeout(terminateTimer);
+      clearTimeout(forceKillTimer);
       reject(error);
     });
   });
+}
+
+export function readWorkspaceStepTimeoutMs(env = process.env) {
+  const raw = env.CRABPOT_WORKSPACE_STEP_TIMEOUT_MS;
+  if (!raw) {
+    return 0;
+  }
+  if (!/^[1-9][0-9]*$/u.test(raw)) {
+    throw new Error("CRABPOT_WORKSPACE_STEP_TIMEOUT_MS must be a positive integer");
+  }
+  return Number(raw);
+}
+
+function terminateProcessGroup(child) {
+  if (!child.pid) {
+    return undefined;
+  }
+  const signal = "SIGTERM";
+  try {
+    if (process.platform === "win32") {
+      child.kill(signal);
+    } else {
+      process.kill(-child.pid, signal);
+    }
+  } catch {
+    // The process may have exited between the timeout firing and the signal.
+  }
+  const killTimer = setTimeout(() => {
+    try {
+      if (process.platform === "win32") {
+        child.kill("SIGKILL");
+      } else {
+        process.kill(-child.pid, "SIGKILL");
+      }
+    } catch {
+      // Already gone.
+    }
+  }, 5_000);
+  killTimer.unref?.();
+  return killTimer;
 }
 
 export function executionEnvForStep(step, operationEnv = {}) {

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -96,6 +96,7 @@ test("track dashboard workflow refreshes branch dashboards by OpenClaw track", a
   assert.match(workflow, /node scripts\/run-static-suite\.mjs[\s\S]*--openclaw \.\/openclaw[\s\S]*--plugin-inspector-smoke/);
   assert.match(workflow, /CRABPOT_FIXTURE_SET: \$\{\{ matrix\.fixture_set \}\}/);
   assert.match(workflow, /CRABPOT_PLUGIN_TRACK: \$\{\{ matrix\.plugin_track \}\}/);
+  assert.match(workflow, /CRABPOT_WORKSPACE_STEP_TIMEOUT_MS: "300000"/);
   assert.match(workflow, /corepack prepare "\$\(node -p "require\('\.\/openclaw\/package\.json'\)\.packageManager\.split\('\+'\)\[0\]"\)" --activate/);
   assert.match(workflow, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
   assert.match(workflow, /execution_fixture_set="all"/);

--- a/test/execute-workspace-plan.test.mjs
+++ b/test/execute-workspace-plan.test.mjs
@@ -6,6 +6,8 @@ import { repoRoot } from "../scripts/manifest-lib.mjs";
 import {
   executionEnvForStep,
   parsePortableStep,
+  readWorkspaceStepTimeoutMs,
+  runStep,
   validateExecutionRequest,
   selectWorkspaceSteps,
 } from "../scripts/execute-workspace-plan.mjs";
@@ -339,6 +341,38 @@ test("workspace executor gives process steps fixture-scoped home directories", (
   assert.match(env.HOME, /\.crabpot[/\\]home[/\\]clawrouter$/);
   assert.equal(env.USERPROFILE, env.HOME);
   assert.equal(env.OPENCLAW_HOME, path.join(env.HOME, ".openclaw"));
+});
+
+test("workspace executor bounds hung process steps", async () => {
+  const previous = process.env.CRABPOT_WORKSPACE_STEP_TIMEOUT_MS;
+  process.env.CRABPOT_WORKSPACE_STEP_TIMEOUT_MS = "50";
+  try {
+    const result = await runStep({
+      kind: "capture",
+      command: `${process.execPath} -e "setTimeout(() => {}, 1000)"`,
+      cwd: ".",
+    });
+
+    assert.equal(result.exitCode, 124);
+    assert.equal(result.timedOut, true);
+    assert.equal(result.timeoutMs, 50);
+    assert.ok(result.wallMs < 1000, `expected timeout before sleep completed, got ${result.wallMs}ms`);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CRABPOT_WORKSPACE_STEP_TIMEOUT_MS;
+    } else {
+      process.env.CRABPOT_WORKSPACE_STEP_TIMEOUT_MS = previous;
+    }
+  }
+});
+
+test("workspace executor validates process step timeout configuration", () => {
+  assert.equal(readWorkspaceStepTimeoutMs({}), 0);
+  assert.equal(readWorkspaceStepTimeoutMs({ CRABPOT_WORKSPACE_STEP_TIMEOUT_MS: "120000" }), 120000);
+  assert.throws(
+    () => readWorkspaceStepTimeoutMs({ CRABPOT_WORKSPACE_STEP_TIMEOUT_MS: "1s" }),
+    /CRABPOT_WORKSPACE_STEP_TIMEOUT_MS/,
+  );
 });
 
 test("workspace executor CLI emits a narrow dry-run plan", () => {


### PR DESCRIPTION
## Summary
- add an opt-in per-step timeout for isolated workspace process execution
- apply a 5 minute timeout to dashboard branch writes so one hung fixture cannot pin the whole beta hydration run
- cover the timeout parser, timeout behavior, and workflow wiring

## Verification
- node --test test/execute-workspace-plan.test.mjs test/ci-workflows.test.mjs
- git diff --check

## Context
- Current beta hydration run https://github.com/openclaw/crabpot/actions/runs/26498747837 is stuck in `Write branch dashboard`.