### PR TITLE
fix(dashboard): classify beta harness gaps

### DIFF
--- a/crabpot.ci-policy.json
+++ b/crabpot.ci-policy.json
@@ -64,6 +64,13 @@
       "reasonIncludes": "captured memory tool requires the host embedding provider runtime",
       "decision": "allowed-blocked",
       "until": "memory synthetic probes can inject a host embedding runtime"
+    },
+    {
+      "id": "transcript-source-provider-metadata",
+      "seam": "registerTranscriptSourceProvider",
+      "reasonIncludes": "captured registration has no execution profile",
+      "decision": "allowed-blocked",
+      "until": "transcript source provider synthetic probes can execute provider runtime hooks"
     }
   ],
   "expectedWarnings": [

--- a/crabpot.config.json
+++ b/crabpot.config.json
@@ -456,6 +456,16 @@
           "registerChannel"
         ]
       },
+      "execution": {
+        "blockedFailures": [
+          {
+            "id": "discord-subagent-state-dir-runtime",
+            "seam": "subagent_ended",
+            "errorIncludes": "Received function resolveStateDir.name",
+            "reason": "captured Discord subagent hook requires the host state-dir runtime"
+          }
+        ]
+      },
       "why": "Official OpenClaw Discord channel package covering subagent routing hooks, message policy, account auth, and npm artifact packaging from the monorepo."
     },
     {
@@ -1134,6 +1144,16 @@
         "hooks": ["before_prompt_build", "gateway_stop", "agent_end"],
         "registrations": ["registerTool", "registerCli"]
       },
+      "execution": {
+        "blockedFailures": [
+          {
+            "id": "memory-tencentdb-message-content-runtime",
+            "seam": "before_message_write",
+            "errorIncludes": "reading 'content'",
+            "reason": "captured memory write hook requires host message content"
+          }
+        ]
+      },
       "why": "NPM-pinned memory fixture covering automatic recall/capture hooks, TencentDB vector storage, SQLite fallback, cleanup lifecycle, and seed/export CLI commands."
     },
     {
@@ -1284,6 +1304,12 @@
             "seam": "registerTool",
             "errorIncludes": "fetch failed",
             "reason": "captured tool requires live network access"
+          },
+          {
+            "id": "clawrouter-endpoint-path-runtime",
+            "seam": "registerTool",
+            "errorIncludes": "invalid path ''",
+            "reason": "captured ClawRouter endpoint tool requires configured endpoint path input"
           }
         ]
       },
@@ -1350,6 +1376,28 @@
       "expect": {
         "hooks": ["inbound_claim"],
         "registrations": ["registerService"]
+      },
+      "execution": {
+        "blockedFailures": [
+          {
+            "id": "codex-app-server-conversation-binding-runtime",
+            "seam": "onConversationBindingResolved",
+            "errorIncludes": "reading 'conversation'",
+            "reason": "captured conversation-binding hook requires host conversation context"
+          },
+          {
+            "id": "codex-app-server-interactive-payload-runtime",
+            "seam": "registerInteractiveHandler",
+            "errorIncludes": "reading 'payload'",
+            "reason": "captured interactive handler requires host callback payload"
+          },
+          {
+            "id": "codex-app-server-command-text-runtime",
+            "seam": "registerCommand",
+            "errorIncludes": "reading 'trim'",
+            "reason": "captured command handler requires host command text"
+          }
+        ]
       },
       "why": "Bridge fixture for process launch policy, install safety gates, and channel-specific SDK compatibility."
     },

--- a/test/ci-policy.test.mjs
+++ b/test/ci-policy.test.mjs
@@ -150,6 +150,25 @@ test("default ci policy classifies HTTP route descriptor blockers", async () => 
   );
 });
 
+test("default ci policy classifies transcript source metadata blockers", async () => {
+  const report = await buildCiPolicyReport({
+    compatibilityReport: compatibilityReport(),
+    executionResults: executionResults([
+      {
+        seam: "registerTranscriptSourceProvider",
+        reason: "captured registration has no execution profile",
+      },
+    ]),
+  });
+
+  assert.equal(report.status, "pass");
+  assert.deepEqual(
+    report.checks.filter((check) => check.id.startsWith("execution-results.blocked.")).map((check) => check.action),
+    ["warn"],
+  );
+  assert.equal(validateCiPolicyReport(report).length, 0);
+});
+
 test("ci policy fails ref diff hard regressions", async () => {
   const report = await buildCiPolicyReport({
     policy,

--- a/test/synthetic-probes.test.mjs
+++ b/test/synthetic-probes.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 import { buildContractCapture } from "../scripts/capture-contracts.mjs";
+import { readConfiguredManifest } from "../scripts/manifest-lib.mjs";
 import {
   applyFixtureSyntheticFailurePolicy,
   buildSyntheticProbePlan,
@@ -218,4 +219,59 @@ test("fixture execution policy classifies known live tool failures as blocked", 
   assert.equal(result.results[0].status, "blocked");
   assert.equal(result.results[0].reason, "captured tool requires live network access");
   assert.equal(result.results[1].status, "fail");
+});
+
+test("fixture execution policy classifies beta dashboard harness gaps", async () => {
+  const manifest = await readConfiguredManifest();
+  const cases = [
+    {
+      fixture: "clawrouter",
+      seam: "registerTool",
+      error: "predexon_endpoint_call: invalid path ''",
+      blockedBy: "clawrouter-endpoint-path-runtime",
+    },
+    {
+      fixture: "codex-app-server",
+      seam: "registerCommand",
+      error: "Cannot read properties of undefined (reading 'trim')",
+      blockedBy: "codex-app-server-command-text-runtime",
+    },
+    {
+      fixture: "discord",
+      seam: "subagent_ended",
+      error: 'The "path" argument must be of type string. Received function resolveStateDir.name',
+      blockedBy: "discord-subagent-state-dir-runtime",
+    },
+    {
+      fixture: "memory-tencentdb",
+      seam: "before_message_write",
+      error: "Cannot read properties of undefined (reading 'content')",
+      blockedBy: "memory-tencentdb-message-content-runtime",
+    },
+  ];
+
+  for (const item of cases) {
+    const result = applyFixtureSyntheticFailurePolicy(
+      {
+        entrypoint: path.join(repoRoot, `.crabpot/workspaces/${item.fixture}/index.js`),
+        status: "captured",
+        summary: { probeCount: 1, passCount: 0, failCount: 1, blockedCount: 0 },
+        results: [
+          {
+            captureIndex: 0,
+            kind: item.seam.startsWith("register") ? "registration" : "hook",
+            seam: item.seam,
+            label: item.seam,
+            status: "fail",
+            error: item.error,
+          },
+        ],
+      },
+      manifest,
+    );
+
+    assert.deepEqual(result.summary, { probeCount: 1, passCount: 0, failCount: 0, blockedCount: 1 });
+    assert.equal(result.results[0].status, "blocked");
+    assert.equal(result.results[0].blockedBy, item.blockedBy);
+  }
 });


### PR DESCRIPTION
## Summary
- classify known beta dashboard synthetic harness gaps as fixture-level blocked outcomes
- allow transcript source provider metadata captures in CI policy
- add focused policy and fixture execution tests for the observed beta run failures

## Verification
- node --test test/ci-policy.test.mjs
- node --test --test-name-pattern "fixture execution policy|transcript source providers|HTTP routes blocked|CLI" test/synthetic-probes.test.mjs
- git diff --check

## Context
- Follow-up to https://github.com/openclaw/crabpot/actions/runs/26498747837: the beta dashboard finished execution but failed policy validation on known synthetic harness gaps.