### PR TITLE
fix(dashboard): allow beta harness blockers

### DIFF
--- a/crabpot.ci-policy.json
+++ b/crabpot.ci-policy.json
@@ -71,6 +71,48 @@
       "reasonIncludes": "captured registration has no execution profile",
       "decision": "allowed-blocked",
       "until": "transcript source provider synthetic probes can execute provider runtime hooks"
+    },
+    {
+      "id": "clawrouter-endpoint-path-runtime",
+      "seam": "registerTool",
+      "reasonIncludes": "captured ClawRouter endpoint tool requires configured endpoint path input",
+      "decision": "allowed-blocked",
+      "until": "endpoint tool synthetic probes can inject configured path arguments"
+    },
+    {
+      "id": "codex-app-server-conversation-binding-runtime",
+      "seam": "onConversationBindingResolved",
+      "reasonIncludes": "captured conversation-binding hook requires host conversation context",
+      "decision": "allowed-blocked",
+      "until": "conversation-binding synthetic probes can inject host conversation context"
+    },
+    {
+      "id": "codex-app-server-interactive-payload-runtime",
+      "seam": "registerInteractiveHandler",
+      "reasonIncludes": "captured interactive handler requires host callback payload",
+      "decision": "allowed-blocked",
+      "until": "interactive-handler synthetic probes can inject callback payloads"
+    },
+    {
+      "id": "codex-app-server-command-text-runtime",
+      "seam": "registerCommand",
+      "reasonIncludes": "captured command handler requires host command text",
+      "decision": "allowed-blocked",
+      "until": "command-handler synthetic probes can inject command text"
+    },
+    {
+      "id": "discord-subagent-state-dir-runtime",
+      "seam": "subagent_ended",
+      "reasonIncludes": "captured Discord subagent hook requires the host state-dir runtime",
+      "decision": "allowed-blocked",
+      "until": "subagent hook synthetic probes can inject host state-dir runtime"
+    },
+    {
+      "id": "memory-tencentdb-message-content-runtime",
+      "seam": "before_message_write",
+      "reasonIncludes": "captured memory write hook requires host message content",
+      "decision": "allowed-blocked",
+      "until": "memory write synthetic probes can inject host message content"
     }
   ],
   "expectedWarnings": [

--- a/test/ci-policy.test.mjs
+++ b/test/ci-policy.test.mjs
@@ -169,6 +169,45 @@ test("default ci policy classifies transcript source metadata blockers", async (
   assert.equal(validateCiPolicyReport(report).length, 0);
 });
 
+test("default ci policy classifies beta dashboard harness blockers", async () => {
+  const report = await buildCiPolicyReport({
+    compatibilityReport: compatibilityReport(),
+    executionResults: executionResults([
+      {
+        seam: "registerTool",
+        reason: "captured ClawRouter endpoint tool requires configured endpoint path input",
+      },
+      {
+        seam: "onConversationBindingResolved",
+        reason: "captured conversation-binding hook requires host conversation context",
+      },
+      {
+        seam: "registerInteractiveHandler",
+        reason: "captured interactive handler requires host callback payload",
+      },
+      {
+        seam: "registerCommand",
+        reason: "captured command handler requires host command text",
+      },
+      {
+        seam: "subagent_ended",
+        reason: "captured Discord subagent hook requires the host state-dir runtime",
+      },
+      {
+        seam: "before_message_write",
+        reason: "captured memory write hook requires host message content",
+      },
+    ]),
+  });
+
+  assert.equal(report.status, "pass");
+  assert.deepEqual(
+    report.checks.filter((check) => check.id.startsWith("execution-results.blocked.")).map((check) => check.action),
+    ["warn", "warn", "warn", "warn", "warn", "warn"],
+  );
+  assert.equal(validateCiPolicyReport(report).length, 0);
+});
+
 test("ci policy fails ref diff hard regressions", async () => {
   const report = await buildCiPolicyReport({
     policy,


### PR DESCRIPTION
## Summary
- allow known beta host-context blockers in the CI policy
- cover the beta dashboard blocked reasons with a focused CI policy test

## Verification
- node --test test/ci-policy.test.mjs
- git diff --check
- node scripts/check-ci-policy.mjs --check --execution-results /tmp/crabpot-run-26501078585/crabpot-track-beta-reports/crabpot-execution-results.json --report /tmp/crabpot-run-26501078585/crabpot-track-beta-reports/crabpot-report.json --policy crabpot.ci-policy.json --json