### PR TITLE
Add Crabpot LCM behavior eval gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Behavior evals are profile-driven, default to a dry plan, and stay
 credential-free unless execution is explicitly enabled. The default profile is
 the forward LCM release gate against latest OpenClaw and latest
 `@martian-engineering/lossless-claw`. It verifies recall inside one stable
-session-key family, which is LCM's supported context boundary:
+session-key family after `/lossless rotate`, which exercises LCM-owned
+transcript maintenance before the recall turn:
 
 ```bash
 npm run eval:behavior
@@ -183,8 +184,9 @@ npm run eval:behavior -- --profile forward-context-engine-quarantine-gate
 
 Execution is opt-in and isolated. The current POC stages a QA-lab-style mock
 model provider, starts an isolated gateway, drives `chat.send` -> `agent.wait`
--> `chat.history`, and checks the latest assistant response on a second turn
-using the same stable session key:
+-> `chat.history`, requires the `/lossless rotate` command response, and checks
+the latest assistant response on the recall turn using the same stable session
+key:
 
 ```bash
 CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --execute --profile recent-lcm-2026-5-22 --runner local --timeout-ms 120000

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For deeper review, open the reports in this order:
 | Why plugin entrypoints cannot be safely cold-imported yet | `npm run cold-import` | `reports/crabpot-cold-import.md` |
 | Isolated install/build/capture commands Crabpot would run | `npm run workspace:plan` | `reports/crabpot-workspace-plan.md` |
 | Results from opt-in isolated fixture execution | `npm run execution:report` | `reports/crabpot-execution-results.md` |
+| Behavioral eval planning for plugin categories | `npm run eval:behavior` | stdout / `.crabpot/results/behavior/` when executed |
 | Boot time and RSS against the target OpenClaw registry surface | `npm run profile` | `reports/crabpot-runtime-profile.md` |
 | China and adjacent external plugin monitor candidates | manual live discovery pass | `reports/crabpot-external-plugin-monitor.md` |
 | README dashboard refresh from all generated JSON reports | `npm run readme:summary` | `README.md`, `reports/crabpot-dashboard-data.json` |
@@ -151,6 +152,44 @@ future inspector tooling. The JSON is the contract; the Markdown is the review
 surface. `reports/crabpot-dashboard-data.json` is the compact machine-readable
 dashboard card used to compare `crab-beta` and `crab-development` against
 `main`.
+
+## Behavioral eval POC
+
+Behavior evals are profile-driven, default to a dry plan, and stay
+credential-free unless execution is explicitly enabled. The default profile is
+the forward LCM release gate against latest OpenClaw and latest
+`@martian-engineering/lossless-claw`:
+
+```bash
+npm run eval:behavior
+```
+
+Run the recent historical repro target from Discord chatter with:
+
+```bash
+npm run eval:behavior -- --profile recent-lcm-2026-5-22 --json
+```
+
+Execution is opt-in and isolated. The current POC stages a QA-lab-style mock
+model provider, starts an isolated gateway, drives `chat.send` -> `agent.wait`
+-> `chat.history`, and checks the latest assistant response on a second turn:
+
+```bash
+CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --execute --profile recent-lcm-2026-5-22 --runner local --timeout-ms 120000
+```
+
+The historical LCM target is intentionally red: `openclaw@2026.5.22` with
+`@martian-engineering/lossless-claw@0.11.2` is expected to fail with
+`memory-recall-mismatch`. A forward release-gate proof can pin a newer OpenClaw
+package while keeping the same LCM plugin:
+
+```bash
+CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --execute --profile forward-lcm-release-gate --openclaw-version 2026.5.26 --plugin npm:@martian-engineering/lossless-claw@0.11.2 --expect must-pass --runner local --timeout-ms 240000
+```
+
+Behavior eval execution writes an empty npm user config inside the temp
+workspace so local npm policy, such as a `before` cutoff, does not silently move
+`latest` back to an older release.
 
 Use the main compatibility report like this:
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ Run the recent historical repro target from Discord chatter with:
 npm run eval:behavior -- --profile recent-lcm-2026-5-22 --json
 ```
 
+The companion quarantine gate installs a synthetic malformed context-engine
+plugin, selects it in the active slot, requires the agent turn to continue
+through downgrade/default behavior, and checks gateway health for the quarantine:
+
+```bash
+npm run eval:behavior -- --profile forward-context-engine-quarantine-gate
+```
+
 Execution is opt-in and isolated. The current POC stages a QA-lab-style mock
 model provider, starts an isolated gateway, drives `chat.send` -> `agent.wait`
 -> `chat.history`, and checks the latest assistant response on a second turn:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ npm run eval:behavior -- --profile recent-lcm-2026-5-22 --json
 
 The companion quarantine gate installs a synthetic malformed context-engine
 plugin, selects it in the active slot, requires the agent turn to continue
-through downgrade/default behavior, and checks gateway health for the quarantine:
+through downgrade/default behavior, and tracks the gateway health quarantine
+signal as an expected failure until that OpenClaw health contract ships in
+`latest`:
 
 ```bash
 npm run eval:behavior -- --profile forward-context-engine-quarantine-gate

--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ dashboard card used to compare `crab-beta` and `crab-development` against
 
 Behavior evals are profile-driven, default to a dry plan, and stay
 credential-free unless execution is explicitly enabled. The default profile is
-the forward LCM release gate against latest OpenClaw and latest
+the forward LCM tracking gate against latest OpenClaw and latest
 `@martian-engineering/lossless-claw`. It verifies recall inside one stable
-session-key family after `/lossless rotate`, which exercises LCM-owned
-transcript maintenance before the recall turn:
+session-key family after `/lossless rotate`, with the seed pushed behind the
+fresh tail so raw transcript replay is not enough to pass:
 
 ```bash
 npm run eval:behavior
@@ -193,9 +193,13 @@ CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --execute --profile recent-l
 ```
 
 The historical LCM target is intentionally red: `openclaw@2026.5.22` with
-`@martian-engineering/lossless-claw@0.11.2` is expected to fail with
-`memory-recall-mismatch`. A forward release-gate proof can pin a newer OpenClaw
-package while keeping the same LCM plugin:
+`@martian-engineering/lossless-claw@0.11.2` may fail before final recall as a
+`behavior-turn-mismatch`, or at final recall with `memory-recall-mismatch`. The
+forward LCM target is stricter and only expects the final summary-backed recall
+failure until latest OpenClaw plus LCM can recall after rotate from summarized
+context rather than raw transcript history. To test a candidate fix, pin a
+newer OpenClaw
+package while keeping the same LCM plugin and override the expectation:
 
 ```bash
 CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --execute --profile forward-lcm-release-gate --openclaw-version 2026.5.26 --plugin npm:@martian-engineering/lossless-claw@0.11.2 --expect must-pass --runner local --timeout-ms 240000

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ dashboard card used to compare `crab-beta` and `crab-development` against
 Behavior evals are profile-driven, default to a dry plan, and stay
 credential-free unless execution is explicitly enabled. The default profile is
 the forward LCM release gate against latest OpenClaw and latest
-`@martian-engineering/lossless-claw`:
+`@martian-engineering/lossless-claw`. It verifies recall inside one stable
+session-key family, which is LCM's supported context boundary:
 
 ```bash
 npm run eval:behavior
@@ -182,7 +183,8 @@ npm run eval:behavior -- --profile forward-context-engine-quarantine-gate
 
 Execution is opt-in and isolated. The current POC stages a QA-lab-style mock
 model provider, starts an isolated gateway, drives `chat.send` -> `agent.wait`
--> `chat.history`, and checks the latest assistant response on a second turn:
+-> `chat.history`, and checks the latest assistant response on a second turn
+using the same stable session key:
 
 ```bash
 CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --execute --profile recent-lcm-2026-5-22 --runner local --timeout-ms 120000

--- a/evals/profiles/forward-context-engine-quarantine-gate.json
+++ b/evals/profiles/forward-context-engine-quarantine-gate.json
@@ -2,9 +2,12 @@
   "id": "forward-context-engine-quarantine-gate",
   "category": "context-engine",
   "scenario": "context-engine-quarantine-fallback",
-  "why": "Default forward gate for context-engine quarantine and downgrade behavior when a selected plugin breaks the active context slot.",
+  "why": "Tracking gate for context-engine quarantine and downgrade behavior when a selected plugin breaks the active context slot. Expected-failure until OpenClaw latest exposes quarantine health.",
   "expectation": {
-    "mode": "must-pass"
+    "mode": "known-failure",
+    "failureClasses": [
+      "context-engine-quarantine-missing"
+    ]
   },
   "openclaw": {
     "source": "npm",

--- a/evals/profiles/forward-context-engine-quarantine-gate.json
+++ b/evals/profiles/forward-context-engine-quarantine-gate.json
@@ -1,0 +1,26 @@
+{
+  "id": "forward-context-engine-quarantine-gate",
+  "category": "context-engine",
+  "scenario": "context-engine-quarantine-fallback",
+  "why": "Default forward gate for context-engine quarantine and downgrade behavior when a selected plugin breaks the active context slot.",
+  "expectation": {
+    "mode": "must-pass"
+  },
+  "openclaw": {
+    "source": "npm",
+    "version": "latest"
+  },
+  "plugins": [
+    {
+      "id": "broken-context-engine",
+      "source": "fixture",
+      "fixture": "broken-context-engine",
+      "slot": "contextEngine"
+    }
+  ],
+  "runner": {
+    "providerMode": "mock-openai",
+    "execution": "blacksmith",
+    "timeoutMs": 900000
+  }
+}

--- a/evals/profiles/forward-lcm-release-gate.json
+++ b/evals/profiles/forward-lcm-release-gate.json
@@ -2,9 +2,10 @@
   "id": "forward-lcm-release-gate",
   "category": "context-engine",
   "scenario": "lcm-basic-memory-turn",
-  "why": "Default forward gate for LCM-style context-engine plugin behavior beyond API seam compatibility.",
+  "why": "Forward tracking gate for LCM-style context-engine plugin behavior beyond API seam compatibility. Expected-failure until latest OpenClaw plus LCM can recall after rotate from summarized context instead of raw transcript replay.",
   "expectation": {
-    "mode": "must-pass"
+    "mode": "known-failure",
+    "failureClasses": ["memory-recall-mismatch"]
   },
   "openclaw": {
     "source": "npm",
@@ -15,7 +16,13 @@
       "id": "lossless-claw",
       "source": "npm",
       "spec": "@martian-engineering/lossless-claw@latest",
-      "slot": "contextEngine"
+      "slot": "contextEngine",
+      "config": {
+        "freshTailCount": 1,
+        "leafMinFanout": 2,
+        "leafChunkTokens": 100,
+        "summaryPrefixTargetTokens": 100
+      }
     }
   ],
   "runner": {

--- a/evals/profiles/forward-lcm-release-gate.json
+++ b/evals/profiles/forward-lcm-release-gate.json
@@ -1,0 +1,26 @@
+{
+  "id": "forward-lcm-release-gate",
+  "category": "context-engine",
+  "scenario": "lcm-basic-memory-turn",
+  "why": "Default forward gate for LCM-style context-engine plugin behavior beyond API seam compatibility.",
+  "expectation": {
+    "mode": "must-pass"
+  },
+  "openclaw": {
+    "source": "npm",
+    "version": "latest"
+  },
+  "plugins": [
+    {
+      "id": "lossless-claw",
+      "source": "npm",
+      "spec": "@martian-engineering/lossless-claw@latest",
+      "slot": "contextEngine"
+    }
+  ],
+  "runner": {
+    "providerMode": "mock-openai",
+    "execution": "blacksmith",
+    "timeoutMs": 900000
+  }
+}

--- a/evals/profiles/recent-lcm-2026-5-22.json
+++ b/evals/profiles/recent-lcm-2026-5-22.json
@@ -8,6 +8,7 @@
     "failureClasses": [
       "embedded-attempt-session-takeover",
       "agent-runner-unavailable",
+      "behavior-turn-mismatch",
       "memory-recall-mismatch"
     ]
   },
@@ -20,7 +21,13 @@
       "id": "lossless-claw",
       "source": "npm",
       "spec": "@martian-engineering/lossless-claw@0.11.2",
-      "slot": "contextEngine"
+      "slot": "contextEngine",
+      "config": {
+        "freshTailCount": 1,
+        "leafMinFanout": 2,
+        "leafChunkTokens": 100,
+        "summaryPrefixTargetTokens": 100
+      }
     }
   ],
   "runner": {

--- a/evals/profiles/recent-lcm-2026-5-22.json
+++ b/evals/profiles/recent-lcm-2026-5-22.json
@@ -1,0 +1,31 @@
+{
+  "id": "recent-lcm-2026-5-22",
+  "category": "context-engine",
+  "scenario": "lcm-basic-memory-turn",
+  "why": "Historical repro profile for the recent Discord-reported LCM break on openclaw@2026.5.22 with lossless-claw@0.11.2.",
+  "expectation": {
+    "mode": "known-failure",
+    "failureClasses": [
+      "embedded-attempt-session-takeover",
+      "agent-runner-unavailable",
+      "memory-recall-mismatch"
+    ]
+  },
+  "openclaw": {
+    "source": "npm",
+    "version": "2026.5.22"
+  },
+  "plugins": [
+    {
+      "id": "lossless-claw",
+      "source": "npm",
+      "spec": "@martian-engineering/lossless-claw@0.11.2",
+      "slot": "contextEngine"
+    }
+  ],
+  "runner": {
+    "providerMode": "mock-openai",
+    "execution": "blacksmith",
+    "timeoutMs": 900000
+  }
+}

--- a/evals/scenarios/context-engine-quarantine-fallback.json
+++ b/evals/scenarios/context-engine-quarantine-fallback.json
@@ -1,0 +1,46 @@
+{
+  "id": "context-engine-quarantine-fallback",
+  "category": "context-engine",
+  "description": "Select a malformed context-engine plugin and verify OpenClaw still completes a turn while health reports the quarantine.",
+  "checks": [
+    {
+      "id": "install",
+      "description": "The requested OpenClaw package resolves and the synthetic broken context-engine plugin installs into isolated state."
+    },
+    {
+      "id": "gateway-load",
+      "description": "The gateway starts with the malformed context engine selected in the contextEngine slot."
+    },
+    {
+      "id": "agent-turn",
+      "description": "An agent call completes through the downgraded/default engine instead of bricking OpenClaw."
+    },
+    {
+      "id": "health-quarantine",
+      "description": "Gateway health reports the selected broken context engine as quarantined."
+    }
+  ],
+  "turns": [
+    {
+      "message": "Say ok after loading context.",
+      "expectText": "ok"
+    }
+  ],
+  "healthChecks": [
+    {
+      "method": "health",
+      "params": {
+        "probe": true
+      },
+      "expect": {
+        "contextEngineQuarantines": [
+          {
+            "pluginId": "broken-context-engine",
+            "engineId": "broken-context-engine",
+            "reasonIncludes": "invalid ContextEngine"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/evals/scenarios/lcm-basic-memory-turn.json
+++ b/evals/scenarios/lcm-basic-memory-turn.json
@@ -1,7 +1,7 @@
 {
   "id": "lcm-basic-memory-turn",
   "category": "context-engine",
-  "description": "Install LCM, select it as the context engine, rotate the transcript, and recall a seeded fact through one stable session key.",
+  "description": "Install LCM, select it as the context engine, rotate the transcript, and recall an assistant-seeded fact through one stable session key.",
   "recallScope": "same-session-key",
   "checks": [
     {
@@ -14,18 +14,23 @@
     },
     {
       "id": "agent-turn",
-      "description": "An agent call accepts a seeded memory fact and returns a completed run or a classified failure."
+      "description": "An agent call emits a seeded memory fact and returns a completed run or a classified failure."
     },
     {
       "id": "memory-assembly",
-      "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+      "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the assistant-seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure."
     }
   ],
   "turns": [
     {
       "sessionSuffix": "default",
-      "message": "Remember this exact test fact: CRABPOT_LCM_FACT is blue-lantern-42.",
-      "expectText": "remembered"
+      "message": "Reply with this exact memory marker: CRABPOT_LCM_FACT is blue-lantern-42.",
+      "expectText": "blue-lantern-42"
+    },
+    {
+      "sessionSuffix": "default",
+      "message": "Say one neutral filler response.",
+      "expectText": "ok"
     },
     {
       "sessionSuffix": "default",

--- a/evals/scenarios/lcm-basic-memory-turn.json
+++ b/evals/scenarios/lcm-basic-memory-turn.json
@@ -1,7 +1,7 @@
 {
   "id": "lcm-basic-memory-turn",
   "category": "context-engine",
-  "description": "Install LCM, select it as the context engine, and run two memory-shaped turns through one stable session key.",
+  "description": "Install LCM, select it as the context engine, and recall a seeded fact through one stable session key after a session reset.",
   "recallScope": "same-session-key",
   "checks": [
     {
@@ -18,7 +18,20 @@
     },
     {
       "id": "memory-assembly",
-      "description": "A follow-up turn on the same stable session key can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+      "description": "A follow-up turn on the same stable session key after sessions.reset can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+    }
+  ],
+  "turns": [
+    {
+      "sessionSuffix": "default",
+      "message": "Remember this exact test fact: CRABPOT_LCM_FACT is blue-lantern-42.",
+      "expectText": "remembered"
+    },
+    {
+      "sessionSuffix": "default",
+      "resetBefore": true,
+      "message": "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
+      "expectText": "blue-lantern-42"
     }
   ]
 }

--- a/evals/scenarios/lcm-basic-memory-turn.json
+++ b/evals/scenarios/lcm-basic-memory-turn.json
@@ -1,0 +1,23 @@
+{
+  "id": "lcm-basic-memory-turn",
+  "category": "context-engine",
+  "description": "Install LCM, select it as the context engine, and run one memory-shaped turn through an isolated gateway.",
+  "checks": [
+    {
+      "id": "install",
+      "description": "The requested OpenClaw package resolves and the LCM npm plugin installs into isolated state."
+    },
+    {
+      "id": "gateway-load",
+      "description": "The gateway starts with lossless-claw enabled and selected in the contextEngine slot."
+    },
+    {
+      "id": "agent-turn",
+      "description": "An agent call accepts a seeded memory fact and returns a completed run or a classified failure."
+    },
+    {
+      "id": "memory-assembly",
+      "description": "A follow-up turn can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+    }
+  ]
+}

--- a/evals/scenarios/lcm-basic-memory-turn.json
+++ b/evals/scenarios/lcm-basic-memory-turn.json
@@ -2,6 +2,7 @@
   "id": "lcm-basic-memory-turn",
   "category": "context-engine",
   "description": "Install LCM, select it as the context engine, and run one memory-shaped turn through an isolated gateway.",
+  "recallScope": "cross-session",
   "checks": [
     {
       "id": "install",

--- a/evals/scenarios/lcm-basic-memory-turn.json
+++ b/evals/scenarios/lcm-basic-memory-turn.json
@@ -1,7 +1,7 @@
 {
   "id": "lcm-basic-memory-turn",
   "category": "context-engine",
-  "description": "Install LCM, select it as the context engine, and recall a seeded fact through one stable session key after a session reset.",
+  "description": "Install LCM, select it as the context engine, rotate the transcript, and recall a seeded fact through one stable session key.",
   "recallScope": "same-session-key",
   "checks": [
     {
@@ -18,7 +18,7 @@
     },
     {
       "id": "memory-assembly",
-      "description": "A follow-up turn on the same stable session key after sessions.reset can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+      "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
     }
   ],
   "turns": [
@@ -29,7 +29,11 @@
     },
     {
       "sessionSuffix": "default",
-      "resetBefore": true,
+      "message": "/lossless rotate",
+      "expectText": "status: rotated"
+    },
+    {
+      "sessionSuffix": "default",
       "message": "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
       "expectText": "blue-lantern-42"
     }

--- a/evals/scenarios/lcm-basic-memory-turn.json
+++ b/evals/scenarios/lcm-basic-memory-turn.json
@@ -1,8 +1,8 @@
 {
   "id": "lcm-basic-memory-turn",
   "category": "context-engine",
-  "description": "Install LCM, select it as the context engine, and run one memory-shaped turn through an isolated gateway.",
-  "recallScope": "cross-session",
+  "description": "Install LCM, select it as the context engine, and run two memory-shaped turns through one stable session key.",
+  "recallScope": "same-session-key",
   "checks": [
     {
       "id": "install",
@@ -18,7 +18,7 @@
     },
     {
       "id": "memory-assembly",
-      "description": "A follow-up turn can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+      "description": "A follow-up turn on the same stable session key can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "contract:coverage": "node scripts/check-contract-coverage.mjs",
     "contract:synthetic": "node scripts/synthetic-probes.mjs",
     "execution:report": "node scripts/summarize-execution-results.mjs",
+    "eval:behavior": "node scripts/behavior-eval.mjs",
     "fixtures:resolve": "node scripts/resolve-fixture-set.mjs",
     "cold-import": "node scripts/cold-import-readiness.mjs",
     "workspace:plan": "node scripts/workspace-plan.mjs",

--- a/reports/crabpot-behavior-evals.json
+++ b/reports/crabpot-behavior-evals.json
@@ -12,9 +12,12 @@
       "id": "forward-lcm-release-gate",
       "category": "context-engine",
       "scenario": "lcm-basic-memory-turn",
-      "status": "planned-must-pass",
+      "status": "planned-known-failure",
       "expectation": {
-        "mode": "must-pass"
+        "mode": "known-failure",
+        "failureClasses": [
+          "memory-recall-mismatch"
+        ]
       },
       "stepCount": 7
     }
@@ -27,7 +30,7 @@
       "scenario": {
         "id": "lcm-basic-memory-turn",
         "category": "context-engine",
-        "description": "Install LCM, select it as the context engine, rotate the transcript, and recall a seeded fact through one stable session key.",
+        "description": "Install LCM, select it as the context engine, rotate the transcript, and recall an assistant-seeded fact through one stable session key.",
         "recallScope": "same-session-key",
         "checks": [
           {
@@ -40,18 +43,23 @@
           },
           {
             "id": "agent-turn",
-            "description": "An agent call accepts a seeded memory fact and returns a completed run or a classified failure."
+            "description": "An agent call emits a seeded memory fact and returns a completed run or a classified failure."
           },
           {
             "id": "memory-assembly",
-            "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+            "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the assistant-seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure."
           }
         ],
         "turns": [
           {
             "sessionSuffix": "default",
-            "message": "Remember this exact test fact: CRABPOT_LCM_FACT is blue-lantern-42.",
-            "expectText": "remembered"
+            "message": "Reply with this exact memory marker: CRABPOT_LCM_FACT is blue-lantern-42.",
+            "expectText": "blue-lantern-42"
+          },
+          {
+            "sessionSuffix": "default",
+            "message": "Say one neutral filler response.",
+            "expectText": "ok"
           },
           {
             "sessionSuffix": "default",
@@ -66,17 +74,28 @@
         ]
       },
       "expectation": {
-        "mode": "must-pass"
+        "mode": "known-failure",
+        "failureClasses": [
+          "memory-recall-mismatch"
+        ]
       },
       "plugins": [
         {
           "id": "lossless-claw",
           "source": "npm",
           "spec": "@martian-engineering/lossless-claw@latest",
-          "slot": "contextEngine"
+          "slot": "contextEngine",
+          "config": {
+            "freshTailCount": 1,
+            "leafMinFanout": 2,
+            "leafChunkTokens": 100,
+            "summaryPrefixTargetTokens": 100
+          }
         }
       ],
-      "expectedFailureClasses": [],
+      "expectedFailureClasses": [
+        "memory-recall-mismatch"
+      ],
       "summary": {
         "openclaw": "openclaw@latest",
         "plugins": "@martian-engineering/lossless-claw@latest",
@@ -91,7 +110,13 @@
           },
           "entries": {
             "lossless-claw": {
-              "enabled": true
+              "enabled": true,
+              "config": {
+                "freshTailCount": 1,
+                "leafMinFanout": 2,
+                "leafChunkTokens": 100,
+                "summaryPrefixTargetTokens": 100
+              }
             }
           }
         }
@@ -125,7 +150,13 @@
               },
               "entries": {
                 "lossless-claw": {
-                  "enabled": true
+                  "enabled": true,
+                  "config": {
+                    "freshTailCount": 1,
+                    "leafMinFanout": 2,
+                    "leafChunkTokens": 100,
+                    "summaryPrefixTargetTokens": 100
+                  }
                 }
               }
             }
@@ -140,7 +171,7 @@
         {
           "id": "scenario",
           "title": "Run scenario",
-          "description": "Install LCM, select it as the context engine, rotate the transcript, and recall a seeded fact through one stable session key.",
+          "description": "Install LCM, select it as the context engine, rotate the transcript, and recall an assistant-seeded fact through one stable session key.",
           "checks": [
             "install",
             "gateway-load",
@@ -151,13 +182,15 @@
         {
           "id": "report",
           "title": "Classify result",
-          "description": "Expected mode is must-pass."
+          "description": "Expected mode is known-failure."
         }
       ],
       "report": {
-        "status": "planned-must-pass",
-        "resultMode": "must-pass",
-        "failureClasses": []
+        "status": "planned-known-failure",
+        "resultMode": "known-failure",
+        "failureClasses": [
+          "memory-recall-mismatch"
+        ]
       }
     }
   ]

--- a/reports/crabpot-behavior-evals.json
+++ b/reports/crabpot-behavior-evals.json
@@ -1,0 +1,147 @@
+{
+  "generatedAt": "deterministic",
+  "summary": {
+    "openclaw": "openclaw@latest",
+    "plugins": "@martian-engineering/lossless-claw@latest",
+    "runner": "blacksmith",
+    "providerMode": "mock-openai",
+    "timeoutMs": 900000
+  },
+  "profiles": [
+    {
+      "id": "forward-lcm-release-gate",
+      "category": "context-engine",
+      "scenario": "lcm-basic-memory-turn",
+      "status": "planned-must-pass",
+      "expectation": {
+        "mode": "must-pass"
+      },
+      "stepCount": 7
+    }
+  ],
+  "plans": [
+    {
+      "generatedAt": "deterministic",
+      "profileId": "forward-lcm-release-gate",
+      "category": "context-engine",
+      "scenario": {
+        "id": "lcm-basic-memory-turn",
+        "category": "context-engine",
+        "description": "Install LCM, select it as the context engine, and run two memory-shaped turns through one stable session key.",
+        "recallScope": "same-session-key",
+        "checks": [
+          {
+            "id": "install",
+            "description": "The requested OpenClaw package resolves and the LCM npm plugin installs into isolated state."
+          },
+          {
+            "id": "gateway-load",
+            "description": "The gateway starts with lossless-claw enabled and selected in the contextEngine slot."
+          },
+          {
+            "id": "agent-turn",
+            "description": "An agent call accepts a seeded memory fact and returns a completed run or a classified failure."
+          },
+          {
+            "id": "memory-assembly",
+            "description": "A follow-up turn on the same stable session key can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+          }
+        ]
+      },
+      "expectation": {
+        "mode": "must-pass"
+      },
+      "plugins": [
+        {
+          "id": "lossless-claw",
+          "source": "npm",
+          "spec": "@martian-engineering/lossless-claw@latest",
+          "slot": "contextEngine"
+        }
+      ],
+      "expectedFailureClasses": [],
+      "summary": {
+        "openclaw": "openclaw@latest",
+        "plugins": "@martian-engineering/lossless-claw@latest",
+        "runner": "blacksmith",
+        "providerMode": "mock-openai",
+        "timeoutMs": 900000
+      },
+      "configPatch": {
+        "plugins": {
+          "slots": {
+            "contextEngine": "lossless-claw"
+          },
+          "entries": {
+            "lossless-claw": {
+              "enabled": true
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "id": "isolate",
+          "title": "Create isolated temp state",
+          "description": "Create temp HOME, OPENCLAW_HOME, OPENCLAW_STATE_DIR, OPENCLAW_CONFIG_PATH, and XDG dirs."
+        },
+        {
+          "id": "openclaw",
+          "title": "Resolve OpenClaw CLI",
+          "description": "Use openclaw@latest.",
+          "command": "npm exec --yes --package=openclaw@latest -- openclaw --version"
+        },
+        {
+          "id": "plugin",
+          "title": "Install plugin",
+          "description": "Install lossless-claw.",
+          "command": "npm exec --yes --package=openclaw@latest -- openclaw plugins install npm:@martian-engineering/lossless-claw@latest --pin"
+        },
+        {
+          "id": "config",
+          "title": "Patch isolated config",
+          "description": "Enable plugin entries and select any requested exclusive slot.",
+          "configPatch": {
+            "plugins": {
+              "slots": {
+                "contextEngine": "lossless-claw"
+              },
+              "entries": {
+                "lossless-claw": {
+                  "enabled": true
+                }
+              }
+            }
+          }
+        },
+        {
+          "id": "gateway",
+          "title": "Start gateway",
+          "description": "Run the foreground gateway with provider mode mock-openai.",
+          "command": "npm exec --yes --package=openclaw@latest -- openclaw gateway run --allow-unconfigured --bind loopback --port <free-port> --token <token>"
+        },
+        {
+          "id": "scenario",
+          "title": "Run scenario",
+          "description": "Install LCM, select it as the context engine, and run two memory-shaped turns through one stable session key.",
+          "checks": [
+            "install",
+            "gateway-load",
+            "agent-turn",
+            "memory-assembly"
+          ]
+        },
+        {
+          "id": "report",
+          "title": "Classify result",
+          "description": "Expected mode is must-pass."
+        }
+      ],
+      "report": {
+        "status": "planned-must-pass",
+        "resultMode": "must-pass",
+        "failureClasses": []
+      }
+    }
+  ]
+}

--- a/reports/crabpot-behavior-evals.json
+++ b/reports/crabpot-behavior-evals.json
@@ -27,7 +27,7 @@
       "scenario": {
         "id": "lcm-basic-memory-turn",
         "category": "context-engine",
-        "description": "Install LCM, select it as the context engine, and recall a seeded fact through one stable session key after a session reset.",
+        "description": "Install LCM, select it as the context engine, rotate the transcript, and recall a seeded fact through one stable session key.",
         "recallScope": "same-session-key",
         "checks": [
           {
@@ -44,7 +44,7 @@
           },
           {
             "id": "memory-assembly",
-            "description": "A follow-up turn on the same stable session key after sessions.reset can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+            "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
           }
         ],
         "turns": [
@@ -55,7 +55,11 @@
           },
           {
             "sessionSuffix": "default",
-            "resetBefore": true,
+            "message": "/lossless rotate",
+            "expectText": "status: rotated"
+          },
+          {
+            "sessionSuffix": "default",
             "message": "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
             "expectText": "blue-lantern-42"
           }
@@ -136,7 +140,7 @@
         {
           "id": "scenario",
           "title": "Run scenario",
-          "description": "Install LCM, select it as the context engine, and recall a seeded fact through one stable session key after a session reset.",
+          "description": "Install LCM, select it as the context engine, rotate the transcript, and recall a seeded fact through one stable session key.",
           "checks": [
             "install",
             "gateway-load",

--- a/reports/crabpot-behavior-evals.json
+++ b/reports/crabpot-behavior-evals.json
@@ -27,7 +27,7 @@
       "scenario": {
         "id": "lcm-basic-memory-turn",
         "category": "context-engine",
-        "description": "Install LCM, select it as the context engine, and run two memory-shaped turns through one stable session key.",
+        "description": "Install LCM, select it as the context engine, and recall a seeded fact through one stable session key after a session reset.",
         "recallScope": "same-session-key",
         "checks": [
           {
@@ -44,7 +44,20 @@
           },
           {
             "id": "memory-assembly",
-            "description": "A follow-up turn on the same stable session key can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+            "description": "A follow-up turn on the same stable session key after sessions.reset can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure."
+          }
+        ],
+        "turns": [
+          {
+            "sessionSuffix": "default",
+            "message": "Remember this exact test fact: CRABPOT_LCM_FACT is blue-lantern-42.",
+            "expectText": "remembered"
+          },
+          {
+            "sessionSuffix": "default",
+            "resetBefore": true,
+            "message": "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
+            "expectText": "blue-lantern-42"
           }
         ]
       },
@@ -123,7 +136,7 @@
         {
           "id": "scenario",
           "title": "Run scenario",
-          "description": "Install LCM, select it as the context engine, and run two memory-shaped turns through one stable session key.",
+          "description": "Install LCM, select it as the context engine, and recall a seeded fact through one stable session key after a session reset.",
           "checks": [
             "install",
             "gateway-load",

--- a/reports/crabpot-behavior-evals.md
+++ b/reports/crabpot-behavior-evals.md
@@ -1,0 +1,52 @@
+# Crabpot Behavior Eval Plan
+
+- Profile: forward-lcm-release-gate
+- Category: context-engine
+- Scenario: lcm-basic-memory-turn
+- OpenClaw: openclaw@latest
+- Plugins: @martian-engineering/lossless-claw@latest
+- Runner: blacksmith (mock-openai)
+- Expected mode: must-pass
+
+## Steps
+
+1. Create isolated temp state
+   Create temp HOME, OPENCLAW_HOME, OPENCLAW_STATE_DIR, OPENCLAW_CONFIG_PATH, and XDG dirs.
+2. Resolve OpenClaw CLI
+   Use openclaw@latest.
+
+   ```sh
+   npm exec --yes --package=openclaw@latest -- openclaw --version
+   ```
+
+3. Install plugin
+   Install lossless-claw.
+
+   ```sh
+   npm exec --yes --package=openclaw@latest -- openclaw plugins install npm:@martian-engineering/lossless-claw@latest --pin
+   ```
+
+4. Patch isolated config
+   Enable plugin entries and select any requested exclusive slot.
+5. Start gateway
+   Run the foreground gateway with provider mode mock-openai.
+
+   ```sh
+   npm exec --yes --package=openclaw@latest -- openclaw gateway run --allow-unconfigured --bind loopback --port <free-port> --token <token>
+   ```
+
+6. Run scenario
+   Install LCM, select it as the context engine, and run two memory-shaped turns through one stable session key.
+7. Classify result
+   Expected mode is must-pass.
+## Scenario Checks
+
+- install: The requested OpenClaw package resolves and the LCM npm plugin installs into isolated state.
+- gateway-load: The gateway starts with lossless-claw enabled and selected in the contextEngine slot.
+- agent-turn: An agent call accepts a seeded memory fact and returns a completed run or a classified failure.
+- memory-assembly: A follow-up turn on the same stable session key can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure.
+
+## Planned Classification
+
+- Status: planned-must-pass
+

--- a/reports/crabpot-behavior-evals.md
+++ b/reports/crabpot-behavior-evals.md
@@ -36,7 +36,7 @@
    ```
 
 6. Run scenario
-   Install LCM, select it as the context engine, and run two memory-shaped turns through one stable session key.
+   Install LCM, select it as the context engine, and recall a seeded fact through one stable session key after a session reset.
 7. Classify result
    Expected mode is must-pass.
 ## Scenario Checks
@@ -44,7 +44,7 @@
 - install: The requested OpenClaw package resolves and the LCM npm plugin installs into isolated state.
 - gateway-load: The gateway starts with lossless-claw enabled and selected in the contextEngine slot.
 - agent-turn: An agent call accepts a seeded memory fact and returns a completed run or a classified failure.
-- memory-assembly: A follow-up turn on the same stable session key can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure.
+- memory-assembly: A follow-up turn on the same stable session key after sessions.reset can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure.
 
 ## Planned Classification
 

--- a/reports/crabpot-behavior-evals.md
+++ b/reports/crabpot-behavior-evals.md
@@ -6,7 +6,8 @@
 - OpenClaw: openclaw@latest
 - Plugins: @martian-engineering/lossless-claw@latest
 - Runner: blacksmith (mock-openai)
-- Expected mode: must-pass
+- Expected mode: known-failure
+- Expected failure classes: memory-recall-mismatch
 
 ## Steps
 
@@ -36,17 +37,17 @@
    ```
 
 6. Run scenario
-   Install LCM, select it as the context engine, rotate the transcript, and recall a seeded fact through one stable session key.
+   Install LCM, select it as the context engine, rotate the transcript, and recall an assistant-seeded fact through one stable session key.
 7. Classify result
-   Expected mode is must-pass.
+   Expected mode is known-failure.
 ## Scenario Checks
 
 - install: The requested OpenClaw package resolves and the LCM npm plugin installs into isolated state.
 - gateway-load: The gateway starts with lossless-claw enabled and selected in the contextEngine slot.
-- agent-turn: An agent call accepts a seeded memory fact and returns a completed run or a classified failure.
-- memory-assembly: A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure.
+- agent-turn: An agent call emits a seeded memory fact and returns a completed run or a classified failure.
+- memory-assembly: A follow-up turn on the same stable session key after /lossless rotate can observe the assistant-seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure.
 
 ## Planned Classification
 
-- Status: planned-must-pass
+- Status: planned-known-failure
 

--- a/reports/crabpot-behavior-evals.md
+++ b/reports/crabpot-behavior-evals.md
@@ -36,7 +36,7 @@
    ```
 
 6. Run scenario
-   Install LCM, select it as the context engine, and recall a seeded fact through one stable session key after a session reset.
+   Install LCM, select it as the context engine, rotate the transcript, and recall a seeded fact through one stable session key.
 7. Classify result
    Expected mode is must-pass.
 ## Scenario Checks
@@ -44,7 +44,7 @@
 - install: The requested OpenClaw package resolves and the LCM npm plugin installs into isolated state.
 - gateway-load: The gateway starts with lossless-claw enabled and selected in the contextEngine slot.
 - agent-turn: An agent call accepts a seeded memory fact and returns a completed run or a classified failure.
-- memory-assembly: A follow-up turn on the same stable session key after sessions.reset can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure.
+- memory-assembly: A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through assembled context, or the run is classified as an LCM assembly failure.
 
 ## Planned Classification
 

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1,0 +1,1860 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const repoRoot = path.resolve(import.meta.dirname, "..");
+export const defaultProfileDir = path.join(repoRoot, "evals", "profiles");
+export const defaultScenarioDir = path.join(repoRoot, "evals", "scenarios");
+export const defaultBehaviorEvalJsonPath = path.join(repoRoot, "reports", "crabpot-behavior-evals.json");
+export const defaultBehaviorEvalMarkdownPath = path.join(repoRoot, "reports", "crabpot-behavior-evals.md");
+export const defaultBehaviorEvalResultsDir = path.join(repoRoot, ".crabpot", "results", "behavior");
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const profile = await loadBehaviorEvalProfile(args.profile, {
+    profileDir: args.profileDir,
+  });
+  const resolvedProfile = resolveBehaviorEvalProfile({
+    profile,
+    overrides: {
+      openclawVersion: args.openclawVersion,
+      openclawPath: args.openclawPath,
+      pluginSpec: args.pluginSpec,
+      expectationMode: args.expectationMode,
+      runnerExecution: args.runnerExecution,
+      scenarioId: args.scenarioId,
+    },
+  });
+  const scenario = await loadBehaviorEvalScenario(resolvedProfile.scenario, {
+    scenarioDir: args.scenarioDir,
+  });
+  const plan = buildBehaviorEvalPlan({ profile: resolvedProfile, scenario });
+  const report = renderBehaviorEvalReport(plan);
+  const markdown = renderBehaviorEvalMarkdown(plan);
+
+  if (args.execute) {
+    const execution = await executeBehaviorEvalPlan(plan, {
+      env: process.env,
+      keepTemp: args.keepTemp,
+      timeoutMs: args.timeoutMs,
+    });
+    await writeBehaviorEvalExecutionResult(execution, {
+      resultsDir: args.resultsDir,
+    });
+    const executionReport = {
+      ...report,
+      executions: [execution],
+    };
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(executionReport, null, 2)}\n`);
+      return;
+    }
+    process.stdout.write(renderBehaviorEvalExecutionMarkdown(plan, execution));
+    return;
+  }
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+
+  if (args.check) {
+    await assertReportMatches({ report, markdown, jsonPath: args.jsonPath, markdownPath: args.markdownPath });
+    return;
+  }
+
+  if (args.write) {
+    await writeBehaviorEvalReport({ report, markdown, jsonPath: args.jsonPath, markdownPath: args.markdownPath });
+    process.stdout.write(`behavior eval report: ${path.relative(repoRoot, args.markdownPath)}\n`);
+    return;
+  }
+
+  process.stdout.write(markdown);
+}
+
+function parseArgs(argv) {
+  const args = {
+    check: false,
+    execute: false,
+    json: false,
+    keepTemp: false,
+    write: false,
+    profile: "forward-lcm-release-gate",
+    scenarioId: undefined,
+    profileDir: defaultProfileDir,
+    scenarioDir: defaultScenarioDir,
+    jsonPath: defaultBehaviorEvalJsonPath,
+    markdownPath: defaultBehaviorEvalMarkdownPath,
+    resultsDir: defaultBehaviorEvalResultsDir,
+    openclawVersion: undefined,
+    openclawPath: undefined,
+    pluginSpec: undefined,
+    expectationMode: undefined,
+    runnerExecution: undefined,
+    timeoutMs: undefined,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--profile") {
+      args.profile = requireValue(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--scenario") {
+      args.scenarioId = requireValue(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--profile-dir") {
+      args.profileDir = path.resolve(requireValue(argv, ++index, arg));
+      continue;
+    }
+    if (arg === "--scenario-dir") {
+      args.scenarioDir = path.resolve(requireValue(argv, ++index, arg));
+      continue;
+    }
+    if (arg === "--openclaw-version") {
+      args.openclawVersion = requireValue(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--openclaw") {
+      args.openclawPath = requireValue(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--plugin") {
+      args.pluginSpec = requireValue(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--expect") {
+      args.expectationMode = requireValue(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--runner") {
+      args.runnerExecution = requireValue(argv, ++index, arg);
+      continue;
+    }
+    if (arg === "--json") {
+      args.json = true;
+      continue;
+    }
+    if (arg === "--execute") {
+      args.execute = true;
+      continue;
+    }
+    if (arg === "--keep-temp") {
+      args.keepTemp = true;
+      continue;
+    }
+    if (arg === "--timeout-ms") {
+      args.timeoutMs = parsePositiveInteger(requireValue(argv, ++index, arg), arg);
+      continue;
+    }
+    if (arg === "--write") {
+      args.write = true;
+      continue;
+    }
+    if (arg === "--check") {
+      args.check = true;
+      continue;
+    }
+    if (arg === "--json-path") {
+      args.jsonPath = path.resolve(requireValue(argv, ++index, arg));
+      continue;
+    }
+    if (arg === "--markdown-path") {
+      args.markdownPath = path.resolve(requireValue(argv, ++index, arg));
+      continue;
+    }
+    if (arg === "--results-dir") {
+      args.resultsDir = path.resolve(requireValue(argv, ++index, arg));
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value, flag) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} requires a positive integer`);
+  }
+  return parsed;
+}
+
+export async function loadBehaviorEvalProfile(profileId, options = {}) {
+  const profileDir = options.profileDir ?? defaultProfileDir;
+  const profilePath = path.join(profileDir, `${profileId}.json`);
+  const profile = await readJson(profilePath);
+  validateBehaviorEvalProfile(profile, profilePath);
+  return profile;
+}
+
+export async function loadBehaviorEvalScenario(scenarioId, options = {}) {
+  const scenarioDir = options.scenarioDir ?? defaultScenarioDir;
+  const scenarioPath = path.join(scenarioDir, `${scenarioId}.json`);
+  const scenario = await readJson(scenarioPath);
+  validateBehaviorEvalScenario(scenario, scenarioPath);
+  return scenario;
+}
+
+export function resolveBehaviorEvalProfile({ profile, overrides = {} }) {
+  const next = cloneJson(profile);
+  if (overrides.scenarioId) {
+    next.scenario = overrides.scenarioId;
+  }
+  if (overrides.openclawPath) {
+    next.openclaw = {
+      source: "path",
+      path: overrides.openclawPath,
+    };
+  } else if (overrides.openclawVersion) {
+    next.openclaw = {
+      source: "npm",
+      version: overrides.openclawVersion,
+    };
+  }
+  if (overrides.pluginSpec) {
+    if (!Array.isArray(next.plugins) || next.plugins.length !== 1) {
+      throw new Error("--plugin override requires exactly one plugin in the profile");
+    }
+    next.plugins[0] = {
+      ...next.plugins[0],
+      source: "npm",
+      spec: normalizeNpmPluginSpec(overrides.pluginSpec),
+    };
+  }
+  if (overrides.expectationMode) {
+    next.expectation = {
+      ...next.expectation,
+      mode: overrides.expectationMode,
+    };
+  }
+  if (overrides.runnerExecution) {
+    next.runner = {
+      ...next.runner,
+      execution: overrides.runnerExecution,
+    };
+  }
+  validateBehaviorEvalProfile(next, next.id ?? "profile override");
+  return next;
+}
+
+export function buildBehaviorEvalPlan({ profile, scenario }) {
+  validateBehaviorEvalProfile(profile, profile.id ?? "profile");
+  validateBehaviorEvalScenario(scenario, scenario.id ?? "scenario");
+  if (profile.scenario !== scenario.id) {
+    throw new Error(`profile ${profile.id} references scenario ${profile.scenario}, got ${scenario.id}`);
+  }
+
+  const pluginEntries = Object.fromEntries(
+    profile.plugins.map((plugin) => [
+      plugin.id,
+      {
+        enabled: true,
+      },
+    ]),
+  );
+  const slots = Object.fromEntries(
+    profile.plugins
+      .filter((plugin) => plugin.slot)
+      .map((plugin) => [plugin.slot, plugin.id]),
+  );
+  const openclaw = formatOpenClawTarget(profile.openclaw);
+  const openclawCommand = openclawInvocation(profile.openclaw);
+  const installCommands = profile.plugins.map((plugin) => `${openclawCommand} plugins install ${formatPluginInstallSpec(plugin)} --pin`);
+  const configPatch = {
+    plugins: {
+      ...(Object.keys(slots).length > 0 ? { slots } : {}),
+      entries: pluginEntries,
+    },
+  };
+  const reportStatus = plannedStatusForExpectation(profile.expectation.mode);
+
+  return {
+    generatedAt: "deterministic",
+    profileId: profile.id,
+    category: profile.category,
+    scenario,
+    expectation: cloneJson(profile.expectation),
+    expectedFailureClasses: [...(profile.expectation.failureClasses ?? [])],
+    summary: {
+      openclaw,
+      plugins: profile.plugins.map((plugin) => plugin.spec).join(", "),
+      runner: profile.runner.execution,
+      providerMode: profile.runner.providerMode,
+      timeoutMs: profile.runner.timeoutMs,
+    },
+    configPatch,
+    steps: [
+      {
+        id: "isolate",
+        title: "Create isolated temp state",
+        description: "Create temp HOME, OPENCLAW_HOME, OPENCLAW_STATE_DIR, OPENCLAW_CONFIG_PATH, and XDG dirs.",
+      },
+      {
+        id: "openclaw",
+        title: "Resolve OpenClaw CLI",
+        description: `Use ${openclaw}.`,
+        command: `${openclawCommand} --version`,
+      },
+      {
+        id: "plugin",
+        title: "Install plugin",
+        description: `Install ${profile.plugins.map((plugin) => plugin.id).join(", ")}.`,
+        command: installCommands.join("\n"),
+      },
+      {
+        id: "config",
+        title: "Patch isolated config",
+        description: "Enable plugin entries and select any requested exclusive slot.",
+        configPatch,
+      },
+      {
+        id: "gateway",
+        title: "Start gateway",
+        description: `Run the foreground gateway with provider mode ${profile.runner.providerMode}.`,
+        command: `${openclawCommand} gateway run --allow-unconfigured --bind loopback --port <free-port> --token <token>`,
+      },
+      {
+        id: "scenario",
+        title: "Run scenario",
+        description: scenario.description,
+        checks: scenario.checks.map((check) => check.id),
+      },
+      {
+        id: "report",
+        title: "Classify result",
+        description: `Expected mode is ${profile.expectation.mode}.`,
+      },
+    ],
+    report: {
+      status: reportStatus,
+      resultMode: profile.expectation.mode,
+      failureClasses: [...(profile.expectation.failureClasses ?? [])],
+    },
+  };
+}
+
+export function renderBehaviorEvalReport(plan) {
+  return {
+    generatedAt: plan.generatedAt,
+    summary: plan.summary,
+    profiles: [
+      {
+        id: plan.profileId,
+        category: plan.category,
+        scenario: plan.scenario.id,
+        status: plan.report.status,
+        expectation: plan.expectation,
+        stepCount: plan.steps.length,
+      },
+    ],
+    plans: [plan],
+  };
+}
+
+export function renderBehaviorEvalMarkdown(plan) {
+  const lines = [
+    "# Crabpot Behavior Eval Plan",
+    "",
+    `- Profile: ${plan.profileId}`,
+    `- Category: ${plan.category}`,
+    `- Scenario: ${plan.scenario.id}`,
+    `- OpenClaw: ${plan.summary.openclaw}`,
+    `- Plugins: ${plan.summary.plugins}`,
+    `- Runner: ${plan.summary.runner} (${plan.summary.providerMode})`,
+    `- Expected mode: ${plan.expectation.mode}`,
+  ];
+  if (plan.expectedFailureClasses.length > 0) {
+    lines.push(`- Expected failure classes: ${plan.expectedFailureClasses.join(", ")}`);
+  }
+  lines.push("", "## Steps", "");
+  for (const [index, step] of plan.steps.entries()) {
+    lines.push(`${index + 1}. ${step.title}`);
+    lines.push(`   ${step.description}`);
+    if (step.command) {
+      lines.push("", "   ```sh", indentBlock(step.command, "   "), "   ```", "");
+    }
+  }
+  lines.push("## Scenario Checks", "");
+  for (const check of plan.scenario.checks) {
+    lines.push(`- ${check.id}: ${check.description}`);
+  }
+  lines.push("", "## Planned Classification", "", `- Status: ${plan.report.status}`, "");
+  return `${lines.join("\n")}\n`;
+}
+
+export async function executeBehaviorEvalPlan(plan, options = {}) {
+  validateBehaviorEvalExecutionRequest({ env: options.env });
+  const workspace = options.workspace ?? (await createBehaviorEvalWorkspace());
+  const ownsWorkspace = !options.workspace;
+  const getFreePortFn = options.getFreePort ?? getFreePort;
+  const port = await getFreePortFn();
+  const token = options.gatewayToken ?? `crabpot-${randomUUID()}`;
+  const runCommand = options.runCommand ?? runBehaviorEvalCommand;
+  const startGateway = options.startGateway ?? startBehaviorEvalGateway;
+  const startProvider = options.startProvider ?? startBehaviorEvalProvider;
+  const runScenario = options.runScenario ?? runBehaviorEvalScenario;
+  const runGatewayRpc = options.runGatewayRpc ?? runBehaviorEvalGatewayRpc;
+  const runtimeEnv = buildBehaviorEvalRuntimeEnv({
+    baseEnv: options.env,
+    port,
+    token,
+    workspace,
+  });
+  const timeoutMs = options.timeoutMs ?? plan.summary.timeoutMs;
+  const steps = [];
+  const context = {
+    env: runtimeEnv,
+    port,
+    token,
+    timeoutMs,
+    workspace,
+    openclawCommand: resolveOpenClawCommandFromPlan(plan),
+    providerBaseUrl: undefined,
+    runCommand,
+    runGatewayRpc,
+    gatewayRpcClient: null,
+  };
+  let gatewayHandle = null;
+  let providerHandle = null;
+
+  try {
+    await prepareBehaviorEvalWorkspace(workspace);
+    steps.push({
+      id: "isolate",
+      status: "pass",
+      message: "created isolated OpenClaw state",
+    });
+
+    const openclawStep = plan.steps.find((step) => step.id === "openclaw");
+    if (openclawStep?.command) {
+      steps.push(
+        await runBehaviorEvalStep({
+          id: "openclaw",
+          command: materializeBehaviorEvalCommand(openclawStep.command, context),
+          context,
+          runCommand,
+        }),
+      );
+      if (lastStepFailed(steps)) {
+        return finalizeBehaviorEvalExecution({
+          plan,
+          steps,
+          workspace,
+          port,
+          keptTemp: Boolean(options.keepTemp),
+          token,
+        });
+      }
+    }
+
+    const pluginStep = plan.steps.find((step) => step.id === "plugin");
+    for (const command of splitCommands(pluginStep?.command)) {
+      steps.push(
+        await runBehaviorEvalStep({
+          id: "plugin",
+          command: materializeBehaviorEvalCommand(command, context),
+          context,
+          runCommand,
+        }),
+      );
+      if (lastStepFailed(steps)) {
+        return finalizeBehaviorEvalExecution({
+          plan,
+          steps,
+          workspace,
+          port,
+          keptTemp: Boolean(options.keepTemp),
+          token,
+        });
+      }
+    }
+
+    providerHandle = await startProvider(plan, context);
+    if (providerHandle?.baseUrl) {
+      context.providerBaseUrl = providerHandle.baseUrl;
+    }
+
+    await writeBehaviorEvalConfig({ plan, workspace, context });
+    steps.push({
+      id: "config",
+      status: "pass",
+      message: `wrote ${path.relative(repoRoot, workspace.configPath)}`,
+      configPath: workspace.configPath,
+    });
+
+    const gatewayStep = plan.steps.find((step) => step.id === "gateway");
+    if (gatewayStep?.command) {
+      const command = materializeBehaviorEvalCommand(gatewayStep.command, context);
+      const gatewayResult = await startGateway(command, context);
+      gatewayHandle = gatewayResult.stop ? gatewayResult : null;
+      steps.push({
+        id: "gateway",
+        command,
+        status: gatewayResult.status,
+        stdout: gatewayResult.stdout ?? "",
+        stderr: gatewayResult.stderr ?? "",
+        wallMs: gatewayResult.wallMs ?? 0,
+      });
+      if (lastStepFailed(steps)) {
+        return finalizeBehaviorEvalExecution({
+          plan,
+          steps,
+          workspace,
+          port,
+          keptTemp: Boolean(options.keepTemp),
+          token,
+        });
+      }
+    }
+
+    const scenarioResult = await runScenario(plan, context);
+    steps.push(toBehaviorEvalScenarioStep(scenarioResult));
+    if (lastStepFailed(steps)) {
+      steps.push({
+        id: "report",
+        status: "pass",
+        message: `expected mode was ${plan.expectation.mode}`,
+      });
+      return finalizeBehaviorEvalExecution({
+        plan,
+        steps,
+        workspace,
+        port,
+        keptTemp: Boolean(options.keepTemp),
+        token,
+      });
+    }
+    steps.push({
+      id: "report",
+      status: "pass",
+      message: `expected mode was ${plan.expectation.mode}`,
+    });
+    return finalizeBehaviorEvalExecution({
+      plan,
+      steps,
+      workspace,
+      port,
+      keptTemp: Boolean(options.keepTemp),
+      token,
+    });
+  } finally {
+    if (context.gatewayRpcClient?.stop) {
+      await context.gatewayRpcClient.stop().catch(() => {});
+    }
+    if (gatewayHandle?.stop) {
+      await gatewayHandle.stop().catch(() => {});
+    }
+    if (providerHandle?.stop) {
+      await providerHandle.stop().catch(() => {});
+    }
+    if (ownsWorkspace && !options.keepTemp) {
+      await rm(workspace.tempRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+function validateBehaviorEvalExecutionRequest({ env = process.env }) {
+  if (env.CRABPOT_EXECUTE_BEHAVIOR !== "1") {
+    throw new Error("behavior eval execution requires CRABPOT_EXECUTE_BEHAVIOR=1");
+  }
+}
+
+async function createBehaviorEvalWorkspace() {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-"));
+  return {
+    tempRoot,
+    homeDir: path.join(tempRoot, "home"),
+    workspaceDir: path.join(tempRoot, "workspace"),
+    stateDir: path.join(tempRoot, "state"),
+    configPath: path.join(tempRoot, "config.json"),
+    npmUserConfig: path.join(tempRoot, "npmrc"),
+    xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+    xdgConfigHome: path.join(tempRoot, "xdg-config"),
+    xdgDataHome: path.join(tempRoot, "xdg-data"),
+  };
+}
+
+async function prepareBehaviorEvalWorkspace(workspace) {
+  await Promise.all([
+    mkdir(workspace.homeDir, { recursive: true }),
+    mkdir(resolveBehaviorEvalWorkspaceDir(workspace), { recursive: true }),
+    mkdir(workspace.stateDir, { recursive: true }),
+    mkdir(path.dirname(workspace.configPath), { recursive: true }),
+    mkdir(workspace.xdgCacheHome, { recursive: true }),
+    mkdir(workspace.xdgConfigHome, { recursive: true }),
+    mkdir(workspace.xdgDataHome, { recursive: true }),
+    writeFile(resolveBehaviorEvalNpmUserConfig(workspace), "", "utf8"),
+  ]);
+}
+
+function resolveBehaviorEvalWorkspaceDir(workspace) {
+  return workspace.workspaceDir ?? path.join(workspace.tempRoot, "workspace");
+}
+
+function resolveBehaviorEvalNpmUserConfig(workspace) {
+  return workspace.npmUserConfig ?? path.join(workspace.tempRoot, "npmrc");
+}
+
+function buildBehaviorEvalRuntimeEnv({ baseEnv = process.env, port, token, workspace }) {
+  return {
+    ...baseEnv,
+    HOME: workspace.homeDir,
+    OPENCLAW_HOME: workspace.homeDir,
+    OPENCLAW_CONFIG_PATH: workspace.configPath,
+    OPENCLAW_STATE_DIR: workspace.stateDir,
+    OPENCLAW_OAUTH_DIR: path.join(workspace.stateDir, "credentials"),
+    OPENCLAW_GATEWAY_PORT: String(port),
+    OPENCLAW_GATEWAY_TOKEN: token,
+    OPENCLAW_GATEWAY_URL: `ws://127.0.0.1:${port}`,
+    OPENCLAW_NO_RESPAWN: "1",
+    OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+    OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+    OPENCLAW_SKIP_CANVAS_HOST: "1",
+    OPENCLAW_TEST_FAST: "1",
+    NPM_CONFIG_USERCONFIG: resolveBehaviorEvalNpmUserConfig(workspace),
+    npm_config_userconfig: resolveBehaviorEvalNpmUserConfig(workspace),
+    NPM_CONFIG_BEFORE: "",
+    npm_config_before: "",
+    XDG_CACHE_HOME: workspace.xdgCacheHome,
+    XDG_CONFIG_HOME: workspace.xdgConfigHome,
+    XDG_DATA_HOME: workspace.xdgDataHome,
+  };
+}
+
+async function writeBehaviorEvalConfig({ plan, workspace, context }) {
+  let config = {
+    plugins: plan.configPatch.plugins,
+    agents: {
+      defaults: {
+        workspace: resolveBehaviorEvalWorkspaceDir(workspace),
+        model: {
+          primary: "mock-openai/gpt-5.5",
+        },
+        memorySearch: {
+          sync: {
+            watch: true,
+            watchDebounceMs: 25,
+            onSessionStart: true,
+            onSearch: true,
+          },
+        },
+        models: {
+          "mock-openai/gpt-5.5": {
+            params: {
+              transport: "sse",
+              openaiWsWarmup: false,
+            },
+          },
+          "mock-openai/gpt-5.5-alt": {
+            params: {
+              transport: "sse",
+              openaiWsWarmup: false,
+            },
+          },
+        },
+        subagents: {
+          allowAgents: ["*"],
+          maxConcurrent: 2,
+        },
+      },
+      list: [
+        {
+          id: "qa",
+          default: true,
+          model: {
+            primary: "mock-openai/gpt-5.5",
+          },
+          tools: {
+            profile: "coding",
+          },
+          subagents: {
+            allowAgents: ["*"],
+          },
+        },
+      ],
+    },
+    memory: {
+      backend: "builtin",
+    },
+    tools: {
+      profile: "coding",
+    },
+    gateway: {
+      mode: "local",
+      bind: "loopback",
+      port: context.port,
+      auth: {
+        mode: "token",
+        token: context.token,
+      },
+      controlUi: {
+        enabled: false,
+      },
+    },
+    discovery: {
+      mdns: {
+        mode: "off",
+      },
+    },
+  };
+  if (plan.summary.providerMode === "mock-openai") {
+    const providerBaseUrl = `${(context.providerBaseUrl ?? "http://127.0.0.1:44080").replace(/\/+$/u, "")}/v1`;
+    config = applyBehaviorEvalMockAuthConfig({
+      ...config,
+      models: {
+        mode: "replace",
+        providers: createBehaviorEvalMockProviderMap("mock-openai", providerBaseUrl),
+      },
+    });
+    await writeBehaviorEvalMockAuthProfiles({
+      workspace,
+      providers: ["mock-openai", "openai", "anthropic"],
+    });
+  }
+  await writeFile(workspace.configPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+function behaviorEvalZeroCost() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  };
+}
+
+function createBehaviorEvalMockOpenAiProvider(baseUrl) {
+  return {
+    baseUrl,
+    apiKey: "test",
+    api: "openai-responses",
+    request: {
+      allowPrivateNetwork: true,
+    },
+    models: [
+      {
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        api: "openai-responses",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: behaviorEvalZeroCost(),
+        contextWindow: 128000,
+        maxTokens: 4096,
+      },
+      {
+        id: "gpt-5.5-alt",
+        name: "gpt-5.5-alt",
+        api: "openai-responses",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: behaviorEvalZeroCost(),
+        contextWindow: 128000,
+        maxTokens: 4096,
+      },
+    ],
+  };
+}
+
+function createBehaviorEvalMockAnthropicProvider(baseUrl) {
+  return {
+    baseUrl: baseUrl.replace(/\/v1\/?$/iu, ""),
+    apiKey: "test",
+    api: "anthropic-messages",
+    request: {
+      allowPrivateNetwork: true,
+    },
+    models: [
+      {
+        id: "claude-opus-4-7",
+        name: "claude-opus-4-7",
+        api: "anthropic-messages",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: behaviorEvalZeroCost(),
+        contextWindow: 200000,
+        maxTokens: 4096,
+      },
+    ],
+  };
+}
+
+function cloneBehaviorEvalProvider(provider) {
+  return {
+    ...provider,
+    models: provider.models.map((model) => ({ ...model })),
+  };
+}
+
+function createBehaviorEvalMockProviderMap(primaryProviderId, providerBaseUrl) {
+  const primaryProvider = createBehaviorEvalMockOpenAiProvider(providerBaseUrl);
+  return {
+    [primaryProviderId]: primaryProvider,
+    openai: cloneBehaviorEvalProvider(primaryProvider),
+    anthropic: createBehaviorEvalMockAnthropicProvider(providerBaseUrl),
+  };
+}
+
+function applyBehaviorEvalMockAuthConfig(config) {
+  const authProviders = ["mock-openai", "openai", "anthropic"];
+  return {
+    ...config,
+    auth: {
+      ...config.auth,
+      profiles: {
+        ...config.auth?.profiles,
+        ...Object.fromEntries(
+          authProviders.map((provider) => [
+            `qa-mock-${provider}`,
+            {
+              provider,
+              mode: "api_key",
+              displayName: `QA mock ${provider} credential`,
+            },
+          ]),
+        ),
+      },
+    },
+  };
+}
+
+async function writeBehaviorEvalMockAuthProfiles({ workspace, providers }) {
+  const profiles = Object.fromEntries(
+    providers.map((provider) => [
+      `qa-mock-${provider}`,
+      {
+        type: "api_key",
+        provider,
+        key: "qa-mock-not-a-real-key",
+        displayName: `QA mock ${provider} credential`,
+      },
+    ]),
+  );
+  await Promise.all(
+    ["main", "qa"].map(async (agentId) => {
+      const agentDir = path.join(workspace.stateDir, "agents", agentId, "agent");
+      await mkdir(agentDir, { recursive: true });
+      await writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify({ version: 1, profiles }, null, 2)}\n`,
+        {
+          encoding: "utf8",
+          mode: 0o600,
+        },
+      );
+    }),
+  );
+}
+
+async function runBehaviorEvalStep({ id, command, context, runCommand }) {
+  const result = await runCommand(command, context);
+  const combinedOutput = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  return {
+    id,
+    command,
+    status: result.exitCode === 0 ? "pass" : "fail",
+    exitCode: result.exitCode,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    wallMs: result.wallMs ?? 0,
+    failureClass: result.exitCode === 0 ? undefined : classifyBehaviorEvalFailure(combinedOutput),
+  };
+}
+
+function runBehaviorEvalCommand(command, context) {
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    const stdout = [];
+    const stderr = [];
+    const child = spawn(command, {
+      cwd: context.workspace.tempRoot,
+      env: context.env,
+      shell: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, context.timeoutMs);
+    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      resolve({
+        exitCode: 1,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: String(error),
+        wallMs: Date.now() - startedAt,
+      });
+    });
+    child.on("exit", (code, signal) => {
+      clearTimeout(timeout);
+      resolve({
+        exitCode: signal ? 1 : (code ?? 1),
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        wallMs: Date.now() - startedAt,
+      });
+    });
+  });
+}
+
+async function startBehaviorEvalGateway(command, context) {
+  const startedAt = Date.now();
+  const stdout = [];
+  const stderr = [];
+  const child = spawn(command, {
+    cwd: context.workspace.tempRoot,
+    env: context.env,
+    shell: true,
+    detached: process.platform !== "win32",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+  child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+  const stop = async () => {
+    await stopBehaviorEvalChildProcess(child);
+  };
+  try {
+    await waitForBehaviorEvalGatewayReady({
+      baseUrl: `http://127.0.0.1:${context.port}`,
+      child,
+      logs: () => `${Buffer.concat(stdout).toString("utf8")}\n${Buffer.concat(stderr).toString("utf8")}`,
+      timeoutMs: Math.min(context.timeoutMs, 120_000),
+    });
+    return {
+      status: "pass",
+      stdout: Buffer.concat(stdout).toString("utf8"),
+      stderr: Buffer.concat(stderr).toString("utf8"),
+      wallMs: Date.now() - startedAt,
+      stop,
+    };
+  } catch (error) {
+    await stop().catch(() => {});
+    return {
+      status: "fail",
+      stdout: Buffer.concat(stdout).toString("utf8"),
+      stderr: `${Buffer.concat(stderr).toString("utf8")}\n${formatErrorForReport(error)}`,
+      wallMs: Date.now() - startedAt,
+    };
+  }
+}
+
+export async function stopBehaviorEvalChildProcess(
+  child,
+  { timeoutMs = 5_000, killProcess = process.kill } = {},
+) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  const exited = new Promise((resolve) => {
+    child.once("exit", () => resolve());
+  });
+  signalBehaviorEvalChildProcess(child, "SIGTERM", killProcess);
+  const timeout = setTimeout(() => {
+    signalBehaviorEvalChildProcess(child, "SIGKILL", killProcess);
+  }, timeoutMs);
+  timeout.unref?.();
+
+  await exited;
+  clearTimeout(timeout);
+}
+
+function signalBehaviorEvalChildProcess(child, signal, killProcess) {
+  try {
+    if (process.platform !== "win32" && child.pid) {
+      killProcess(-child.pid, signal);
+      return;
+    }
+    child.kill(signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") {
+      throw error;
+    }
+  }
+}
+
+async function startBehaviorEvalProvider(plan) {
+  if (plan.summary.providerMode !== "mock-openai") {
+    return null;
+  }
+  return await startBehaviorEvalMockOpenAiProvider();
+}
+
+function startBehaviorEvalMockOpenAiProvider() {
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (req.method === "GET" && (url.pathname === "/healthz" || url.pathname === "/readyz")) {
+        writeBehaviorEvalJson(res, 200, { ok: true, status: "live" });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/v1/models") {
+        writeBehaviorEvalJson(res, 200, {
+          data: [
+            { id: "gpt-5.5", object: "model" },
+            { id: "gpt-5.5-alt", object: "model" },
+            { id: "text-embedding-3-small", object: "model" },
+          ],
+        });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/debug/requests") {
+        writeBehaviorEvalJson(res, 200, requests);
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/v1/embeddings") {
+        const body = await readBehaviorEvalJsonBody(req);
+        const inputs = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+        writeBehaviorEvalJson(res, 200, {
+          object: "list",
+          data: inputs.map((value, index) => ({
+            object: "embedding",
+            index,
+            embedding: createBehaviorEvalEmbedding(String(value)),
+          })),
+          model: typeof body.model === "string" && body.model ? body.model : "text-embedding-3-small",
+          usage: {
+            prompt_tokens: inputs.length,
+            total_tokens: inputs.length,
+          },
+        });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/v1/responses") {
+        const body = await readBehaviorEvalJsonBody(req);
+        const inputText = extractBehaviorEvalRequestText(body);
+        requests.push({ body, inputText });
+        const outputText = buildBehaviorEvalMockResponseText(inputText);
+        const events = buildBehaviorEvalMockResponseEvents(outputText);
+        if (body.stream === false) {
+          writeBehaviorEvalJson(res, 200, events.at(-1).response);
+          return;
+        }
+        writeBehaviorEvalSse(res, events);
+        return;
+      }
+      writeBehaviorEvalJson(res, 404, { error: "not found" });
+    } catch (error) {
+      writeBehaviorEvalJson(res, 500, { error: formatErrorForReport(error) });
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("mock provider failed to allocate port"));
+        return;
+      }
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        stop: async () => {
+          await new Promise((closeResolve) => server.close(() => closeResolve()));
+        },
+      });
+    });
+  });
+}
+
+function writeBehaviorEvalJson(res, status, body) {
+  const text = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(text),
+    "cache-control": "no-store",
+  });
+  res.end(text);
+}
+
+function writeBehaviorEvalSse(res, events) {
+  const body = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "content-length": Buffer.byteLength(body),
+    "cache-control": "no-store",
+    connection: "keep-alive",
+  });
+  res.end(body);
+}
+
+async function readBehaviorEvalJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.from(chunk));
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+function createBehaviorEvalEmbedding(input) {
+  const seed = [...input].reduce((sum, char) => sum + char.charCodeAt(0), 0);
+  return Array.from({ length: 64 }, (_, index) => (((seed + index * 17) % 97) - 48) / 48);
+}
+
+function extractBehaviorEvalRequestText(value) {
+  const parts = [];
+  const visit = (node) => {
+    if (typeof node === "string") {
+      parts.push(node);
+      return;
+    }
+    if (!node || typeof node !== "object") {
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        visit(item);
+      }
+      return;
+    }
+    for (const [key, child] of Object.entries(node)) {
+      if (key === "text" || key === "content" || key === "input" || key === "instructions") {
+        visit(child);
+      }
+    }
+  };
+  visit(value);
+  return parts.join("\n");
+}
+
+function buildBehaviorEvalMockResponseText(inputText) {
+  if (/remember.*crabpot_lcm_fact|crabpot_lcm_fact/iu.test(inputText)) {
+    if (/what is crabpot_lcm_fact|recall.*crabpot_lcm_fact/iu.test(inputText)) {
+      return "blue-lantern-42";
+    }
+    return "remembered CRABPOT_LCM_FACT";
+  }
+  return "ok";
+}
+
+function buildBehaviorEvalMockResponseEvents(text) {
+  const item = {
+    type: "message",
+    id: "msg_crabpot_behavior_1",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+  return [
+    {
+      type: "response.output_item.added",
+      item: {
+        type: "message",
+        id: item.id,
+        role: "assistant",
+        status: "in_progress",
+        content: [],
+      },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: item.id,
+      output_index: 0,
+      content_index: 0,
+      delta: text,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: item.id,
+      output_index: 0,
+      content_index: 0,
+      text,
+    },
+    {
+      type: "response.output_item.done",
+      item,
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_crabpot_behavior_1",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 64, output_tokens: 16, total_tokens: 80 },
+      },
+    },
+  ];
+}
+
+async function runBehaviorEvalScenario(plan, context) {
+  const startedAt = Date.now();
+  const turns = resolveBehaviorEvalScenarioTurns(plan.scenario);
+  const sessionKey = `agent:qa:discord:channel:crabpot-${plan.scenario.id}`;
+  const commands = [];
+  const stdout = [];
+  const stderr = [];
+  for (const turn of turns) {
+    const runId = `crabpot-${randomUUID()}`;
+    const waitTimeoutMs = Math.max(1, Math.min(context.timeoutMs, 120_000));
+    const sendParams = {
+      sessionKey,
+      message: turn.message,
+      deliver: false,
+      timeoutMs: waitTimeoutMs,
+      idempotencyKey: runId,
+    };
+    commands.push(`gateway rpc chat.send ${JSON.stringify(sendParams)}`);
+    try {
+      const started = await context.runGatewayRpc("chat.send", sendParams, context, {
+        timeoutMs: Math.min(waitTimeoutMs, 30_000),
+      });
+      stdout.push(`chat.send ${JSON.stringify(started)}`);
+      if (started?.status && !["started", "accepted", "ok"].includes(started.status)) {
+        return {
+          status: "fail",
+          exitCode: 1,
+          command: commands.join("\n"),
+          stdout: stdout.join("\n"),
+          stderr: `chat.send returned ${JSON.stringify(started)}`,
+          wallMs: Date.now() - startedAt,
+        };
+      }
+      const waitRunId = typeof started?.runId === "string" && started.runId ? started.runId : runId;
+      const waitParams = {
+        runId: waitRunId,
+        timeoutMs: waitTimeoutMs,
+      };
+      commands.push(`gateway rpc agent.wait ${JSON.stringify(waitParams)}`);
+      const waited = await context.runGatewayRpc("agent.wait", waitParams, context, {
+        timeoutMs: waitTimeoutMs + 5_000,
+      });
+      stdout.push(`agent.wait ${JSON.stringify(waited)}`);
+      if (waited?.status && waited.status !== "ok") {
+        return {
+          status: "fail",
+          exitCode: 1,
+          command: commands.join("\n"),
+          stdout: stdout.join("\n"),
+          stderr: `agent.wait returned ${JSON.stringify(waited)}`,
+          wallMs: Date.now() - startedAt,
+        };
+      }
+      const historyParams = { sessionKey, limit: 20 };
+      commands.push(`gateway rpc chat.history ${JSON.stringify(historyParams)}`);
+      const history = await context.runGatewayRpc("chat.history", historyParams, context, {
+        timeoutMs: Math.min(waitTimeoutMs, 30_000),
+      });
+      stdout.push(`chat.history ${JSON.stringify(history)}`);
+      const latestAssistantText = extractLatestBehaviorEvalAssistantText(history);
+      if (turn.expectText && !latestAssistantText.includes(turn.expectText)) {
+        return {
+          status: "fail",
+          exitCode: 1,
+          command: commands.join("\n"),
+          stdout: stdout.join("\n"),
+          stderr: `${stderr.join("\n")}\nmemory-recall-mismatch: expected latest assistant message to contain ${turn.expectText}; got ${latestAssistantText || "<empty>"}`,
+          wallMs: Date.now() - startedAt,
+        };
+      }
+    } catch (error) {
+      return {
+        status: "fail",
+        exitCode: 1,
+        command: commands.join("\n"),
+        stdout: stdout.join("\n"),
+        stderr: `${stderr.join("\n")}\n${formatErrorForReport(error)}`,
+        wallMs: Date.now() - startedAt,
+      };
+    }
+  }
+  return {
+    status: "pass",
+    exitCode: 0,
+    command: commands.join("\n"),
+    stdout: stdout.join("\n"),
+    stderr: stderr.join("\n"),
+    wallMs: Date.now() - startedAt,
+  };
+}
+
+function resolveBehaviorEvalScenarioTurns(scenario) {
+  if (Array.isArray(scenario.turns) && scenario.turns.length > 0) {
+    return scenario.turns.map((turn) => ({
+      message: String(turn.message ?? ""),
+      expectText: typeof turn.expectText === "string" ? turn.expectText : undefined,
+    }));
+  }
+  return [
+    {
+      message: "Remember this exact test fact: CRABPOT_LCM_FACT is blue-lantern-42.",
+      expectText: "remembered",
+    },
+    {
+      message: "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
+      expectText: "blue-lantern-42",
+    },
+  ];
+}
+
+async function runBehaviorEvalGatewayRpc(method, params, context, options = {}) {
+  if (!context.gatewayRpcClient) {
+    context.gatewayRpcClient = await createBehaviorEvalGatewayRpcClient({
+      url: `ws://127.0.0.1:${context.port}`,
+      token: context.token,
+      timeoutMs: Math.min(context.timeoutMs, 120_000),
+    });
+  }
+  return await context.gatewayRpcClient.request(method, params, {
+    timeoutMs: options.timeoutMs ?? Math.min(context.timeoutMs, 30_000),
+  });
+}
+
+async function createBehaviorEvalGatewayRpcClient({ url, token, timeoutMs }) {
+  if (typeof WebSocket !== "function") {
+    throw new Error("global WebSocket is unavailable; Node 22+ is required");
+  }
+
+  const ws = new WebSocket(url);
+  const pending = new Map();
+  let connectSent = false;
+  let stopped = false;
+
+  const request = (method, params, options = {}) =>
+    new Promise((resolve, reject) => {
+      if (stopped) {
+        reject(new Error("gateway rpc client stopped"));
+        return;
+      }
+      if (ws.readyState !== WebSocket.OPEN) {
+        reject(new Error("gateway rpc socket is not open"));
+        return;
+      }
+      const id = randomUUID();
+      const timeout =
+        options.timeoutMs === null
+          ? null
+          : setTimeout(() => {
+              pending.delete(id);
+              reject(new Error(`gateway request timeout for ${method}`));
+            }, options.timeoutMs ?? 30_000);
+      pending.set(id, {
+        resolve,
+        reject,
+        timeout,
+        method,
+      });
+      ws.send(JSON.stringify({ type: "req", id, method, params }));
+    });
+
+  const connectPromise = new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`gateway connect timeout for ${url}`)),
+      timeoutMs,
+    );
+    const finish = (error) => {
+      clearTimeout(timeout);
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    };
+
+    ws.addEventListener("error", () => {
+      finish(new Error(`gateway websocket error for ${url}`));
+    });
+    ws.addEventListener("close", (event) => {
+      const reason = typeof event.reason === "string" ? event.reason : "";
+      const error = new Error(`gateway websocket closed (${event.code}): ${reason}`);
+      for (const [, entry] of pending) {
+        if (entry.timeout) {
+          clearTimeout(entry.timeout);
+        }
+        entry.reject(error);
+      }
+      pending.clear();
+      if (!connectSent) {
+        finish(error);
+      }
+    });
+    ws.addEventListener("message", async (event) => {
+      try {
+        const frame = JSON.parse(await readBehaviorEvalWebSocketMessage(event.data));
+        if (frame?.type === "event" && frame.event === "connect.challenge") {
+          if (connectSent) {
+            return;
+          }
+          connectSent = true;
+          const connectParams = {
+            minProtocol: 1,
+            maxProtocol: 999,
+            client: {
+              id: "gateway-client",
+              displayName: "gateway:crabpot-behavior",
+              version: "crabpot",
+              platform: process.platform,
+              mode: "backend",
+            },
+            caps: [],
+            auth: {
+              token,
+            },
+            role: "operator",
+            scopes: ["operator.admin"],
+          };
+          request("connect", connectParams, { timeoutMs: Math.min(timeoutMs, 30_000) })
+            .then(() => finish(null))
+            .catch((error) => finish(error instanceof Error ? error : new Error(String(error))));
+          return;
+        }
+        if (frame?.type !== "res" || typeof frame.id !== "string") {
+          return;
+        }
+        const entry = pending.get(frame.id);
+        if (!entry) {
+          return;
+        }
+        pending.delete(frame.id);
+        if (entry.timeout) {
+          clearTimeout(entry.timeout);
+        }
+        if (frame.ok) {
+          entry.resolve(frame.payload);
+          return;
+        }
+        entry.reject(new Error(frame.error?.message ?? `gateway request failed for ${entry.method}`));
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  });
+
+  await connectPromise;
+
+  return {
+    request,
+    async stop() {
+      stopped = true;
+      for (const [, entry] of pending) {
+        if (entry.timeout) {
+          clearTimeout(entry.timeout);
+        }
+        entry.reject(new Error("gateway rpc client stopped"));
+      }
+      pending.clear();
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close(1000, "crabpot behavior eval complete");
+      }
+    },
+  };
+}
+
+async function readBehaviorEvalWebSocketMessage(data) {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf8");
+  }
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf8");
+  }
+  if (data && typeof data.text === "function") {
+    return await data.text();
+  }
+  return String(data);
+}
+
+function extractBehaviorEvalObjectText(value) {
+  const parts = [];
+  const visit = (node) => {
+    if (typeof node === "string") {
+      parts.push(node);
+      return;
+    }
+    if (!node || typeof node !== "object") {
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        visit(item);
+      }
+      return;
+    }
+    for (const child of Object.values(node)) {
+      visit(child);
+    }
+  };
+  visit(value);
+  return parts.join("\n");
+}
+
+function extractLatestBehaviorEvalAssistantText(history) {
+  const messages = Array.isArray(history?.messages) ? history.messages : [];
+  const assistantTexts = messages
+    .filter((message) => message?.role === "assistant")
+    .map((message) => extractBehaviorEvalObjectText(message).trim())
+    .filter(Boolean);
+  return assistantTexts.at(-1) ?? "";
+}
+
+function toBehaviorEvalScenarioStep(result) {
+  const combinedOutput = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  return {
+    id: "scenario",
+    command: result.command,
+    status: result.status,
+    exitCode: result.exitCode,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    wallMs: result.wallMs ?? 0,
+    failureClass: result.status === "pass" ? undefined : classifyBehaviorEvalFailure(combinedOutput),
+  };
+}
+
+async function waitForBehaviorEvalGatewayReady({ baseUrl, child, logs, timeoutMs }) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`gateway exited before readiness: ${logs()}`);
+    }
+    for (const pathName of ["/readyz", "/healthz"]) {
+      try {
+        const response = await fetch(`${baseUrl}${pathName}`, {
+          method: "HEAD",
+          signal: AbortSignal.timeout(2_000),
+        });
+        if (response.ok) {
+          return;
+        }
+      } catch {
+        // Keep polling until timeout.
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`gateway did not become ready: ${logs()}`);
+}
+
+function finalizeBehaviorEvalExecution({ plan, steps, workspace, port, keptTemp, token }) {
+  const failed = steps.find((step) => step.status === "fail");
+  const failureClass = failed?.failureClass;
+  const expectedFailure = failureClass && plan.expectedFailureClasses.includes(failureClass);
+  const status = failed
+    ? expectedFailure
+      ? "expected-failure"
+      : "fail"
+    : plan.expectation.mode === "known-failure"
+      ? "unexpected-pass"
+      : "pass";
+  return {
+    generatedAt: "deterministic",
+    profileId: plan.profileId,
+    scenario: plan.scenario.id,
+    status,
+    failureClass: failureClass ?? null,
+    expectedFailureClasses: plan.expectedFailureClasses,
+    workspace: {
+      tempRoot: workspace.tempRoot,
+      configPath: workspace.configPath,
+      kept: keptTemp,
+    },
+    gateway: {
+      port,
+      token,
+    },
+    steps,
+  };
+}
+
+async function writeBehaviorEvalExecutionResult(execution, { resultsDir = defaultBehaviorEvalResultsDir } = {}) {
+  const outputDir = path.join(resultsDir, execution.profileId);
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    path.join(outputDir, "execution.json"),
+    `${JSON.stringify(execution, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+function renderBehaviorEvalExecutionMarkdown(plan, execution) {
+  const lines = [
+    "# Crabpot Behavior Eval Execution",
+    "",
+    `- Profile: ${plan.profileId}`,
+    `- Scenario: ${plan.scenario.id}`,
+    `- Status: ${execution.status}`,
+    `- Failure class: ${execution.failureClass ?? "none"}`,
+    `- Temp root: ${execution.workspace.kept ? execution.workspace.tempRoot : "removed"}`,
+    "",
+    "## Steps",
+    "",
+  ];
+  for (const step of execution.steps) {
+    lines.push(`- ${step.status}: ${step.id}${step.failureClass ? ` (${step.failureClass})` : ""}`);
+  }
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function lastStepFailed(steps) {
+  return steps.at(-1)?.status === "fail";
+}
+
+function splitCommands(value) {
+  if (!value) {
+    return [];
+  }
+  return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function materializeBehaviorEvalCommand(command, context) {
+  return command
+    .replaceAll("<free-port>", String(context.port))
+    .replaceAll("<token>", shellQuote(context.token));
+}
+
+function resolveOpenClawCommandFromPlan(plan) {
+  const command = plan.steps.find((step) => step.id === "openclaw")?.command;
+  if (typeof command !== "string" || !command.endsWith(" --version")) {
+    throw new Error("behavior eval plan is missing an OpenClaw --version command");
+  }
+  return command.slice(0, -" --version".length);
+}
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function classifyBehaviorEvalFailure(output) {
+  const text = output.toLowerCase();
+  if (text.includes("embeddedattemptsessiontakeovererror")) {
+    return "embedded-attempt-session-takeover";
+  }
+  if (
+    text.includes("agent runner") ||
+    text.includes("no embedded pi runner") ||
+    text.includes("never starts agent")
+  ) {
+    return "agent-runner-unavailable";
+  }
+  if (text.includes("timed out") || text.includes("timeout")) {
+    return "timeout";
+  }
+  if (text.includes("memory-recall-mismatch")) {
+    return "memory-recall-mismatch";
+  }
+  if (text.includes("gateway")) {
+    return "gateway-unavailable";
+  }
+  return "unclassified";
+}
+
+function formatErrorForReport(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function writeBehaviorEvalReport({ report, markdown, jsonPath = defaultBehaviorEvalJsonPath, markdownPath = defaultBehaviorEvalMarkdownPath }) {
+  await Promise.all([
+    writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8"),
+    writeFile(markdownPath, markdown, "utf8"),
+  ]);
+}
+
+async function assertReportMatches({ report, markdown, jsonPath, markdownPath }) {
+  const expectedJson = `${JSON.stringify(report, null, 2)}\n`;
+  const expectedMarkdown = markdown;
+  const actualJson = existsSync(jsonPath) ? await readFile(jsonPath, "utf8") : "";
+  const actualMarkdown = existsSync(markdownPath) ? await readFile(markdownPath, "utf8") : "";
+  const mismatches = [];
+  if (actualJson !== expectedJson) {
+    mismatches.push(path.relative(repoRoot, jsonPath));
+  }
+  if (actualMarkdown !== expectedMarkdown) {
+    mismatches.push(path.relative(repoRoot, markdownPath));
+  }
+  if (mismatches.length > 0) {
+    throw new Error(`behavior eval reports are stale: ${mismatches.join(", ")}. Run npm run eval:behavior -- --write`);
+  }
+}
+
+function formatOpenClawTarget(openclaw) {
+  if (openclaw.source === "npm") {
+    return `openclaw@${openclaw.version}`;
+  }
+  return `openclaw path ${openclaw.path}`;
+}
+
+function openclawInvocation(openclaw) {
+  if (openclaw.source === "npm") {
+    return `npm exec --yes --package=openclaw@${openclaw.version} -- openclaw`;
+  }
+  return `node ${shellQuote(path.join(openclaw.path, "dist", "index.js"))}`;
+}
+
+function formatPluginInstallSpec(plugin) {
+  if (plugin.source === "npm") {
+    return `npm:${plugin.spec}`;
+  }
+  throw new Error(`unsupported plugin source for ${plugin.id}: ${plugin.source}`);
+}
+
+function normalizeNpmPluginSpec(spec) {
+  return spec.startsWith("npm:") ? spec.slice("npm:".length) : spec;
+}
+
+function plannedStatusForExpectation(mode) {
+  if (mode === "must-pass") {
+    return "planned-must-pass";
+  }
+  if (mode === "known-failure") {
+    return "planned-known-failure";
+  }
+  if (mode === "report-only") {
+    return "planned-report-only";
+  }
+  throw new Error(`unsupported expectation mode: ${mode}`);
+}
+
+function validateBehaviorEvalProfile(profile, label) {
+  const errors = [];
+  if (!profile || typeof profile !== "object") {
+    throw new Error(`${label}: profile must be an object`);
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(profile.id ?? "")) {
+    errors.push("id must be kebab-case");
+  }
+  if (typeof profile.category !== "string" || profile.category.trim().length === 0) {
+    errors.push("category must be set");
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(profile.scenario ?? "")) {
+    errors.push("scenario must be a scenario id");
+  }
+  if (!profile.expectation || typeof profile.expectation !== "object") {
+    errors.push("expectation must be set");
+  } else if (!["must-pass", "known-failure", "report-only"].includes(profile.expectation.mode)) {
+    errors.push("expectation.mode must be must-pass, known-failure, or report-only");
+  }
+  if (!profile.openclaw || typeof profile.openclaw !== "object") {
+    errors.push("openclaw must be set");
+  } else if (profile.openclaw.source === "npm") {
+    if (typeof profile.openclaw.version !== "string" || profile.openclaw.version.trim().length === 0) {
+      errors.push("openclaw.version must be set for npm source");
+    }
+  } else if (profile.openclaw.source === "path") {
+    if (typeof profile.openclaw.path !== "string" || profile.openclaw.path.trim().length === 0) {
+      errors.push("openclaw.path must be set for path source");
+    }
+  } else {
+    errors.push("openclaw.source must be npm or path");
+  }
+  if (!Array.isArray(profile.plugins) || profile.plugins.length === 0) {
+    errors.push("plugins must be non-empty");
+  } else {
+    for (const plugin of profile.plugins) {
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(plugin.id ?? "")) {
+        errors.push("plugin id must be kebab-case");
+      }
+      if (plugin.source !== "npm") {
+        errors.push(`${plugin.id}: plugin source must be npm`);
+      }
+      if (typeof plugin.spec !== "string" || plugin.spec.trim().length === 0) {
+        errors.push(`${plugin.id}: plugin spec must be set`);
+      }
+    }
+  }
+  if (!profile.runner || typeof profile.runner !== "object") {
+    errors.push("runner must be set");
+  } else {
+    if (!["local", "blacksmith"].includes(profile.runner.execution)) {
+      errors.push("runner.execution must be local or blacksmith");
+    }
+    if (typeof profile.runner.providerMode !== "string" || profile.runner.providerMode.trim().length === 0) {
+      errors.push("runner.providerMode must be set");
+    }
+    if (!Number.isInteger(profile.runner.timeoutMs) || profile.runner.timeoutMs <= 0) {
+      errors.push("runner.timeoutMs must be a positive integer");
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`${label}: ${errors.join("; ")}`);
+  }
+}
+
+function validateBehaviorEvalScenario(scenario, label) {
+  const errors = [];
+  if (!scenario || typeof scenario !== "object") {
+    throw new Error(`${label}: scenario must be an object`);
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(scenario.id ?? "")) {
+    errors.push("id must be kebab-case");
+  }
+  if (typeof scenario.category !== "string" || scenario.category.trim().length === 0) {
+    errors.push("category must be set");
+  }
+  if (typeof scenario.description !== "string" || scenario.description.trim().length === 0) {
+    errors.push("description must be set");
+  }
+  if (!Array.isArray(scenario.checks) || scenario.checks.length === 0) {
+    errors.push("checks must be non-empty");
+  } else {
+    for (const check of scenario.checks) {
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(check.id ?? "")) {
+        errors.push("check id must be kebab-case");
+      }
+      if (typeof check.description !== "string" || check.description.trim().length === 0) {
+        errors.push(`${check.id}: check description must be set`);
+      }
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`${label}: ${errors.join("; ")}`);
+  }
+}
+
+async function readJson(jsonPath) {
+  return JSON.parse(await readFile(jsonPath, "utf8"));
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function indentBlock(value, indent) {
+  return value.split(/\r?\n/).map((line) => `${indent}${line}`).join("\n");
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1385,8 +1385,26 @@ async function runBehaviorEvalScenario(plan, context) {
       timeoutMs: waitTimeoutMs,
       idempotencyKey: runId,
     };
-    commands.push(`gateway rpc chat.send ${JSON.stringify(sendParams)}`);
     try {
+      if (turn.resetBefore) {
+        const resetParams = { key: sessionKey, reason: "reset" };
+        commands.push(`gateway rpc sessions.reset ${JSON.stringify(resetParams)}`);
+        const reset = await context.runGatewayRpc("sessions.reset", resetParams, context, {
+          timeoutMs: Math.min(waitTimeoutMs, 30_000),
+        });
+        stdout.push(`sessions.reset ${JSON.stringify(reset)}`);
+        if (reset?.status && reset.status !== "ok") {
+          return {
+            status: "fail",
+            exitCode: 1,
+            command: commands.join("\n"),
+            stdout: stdout.join("\n"),
+            stderr: `sessions.reset returned ${JSON.stringify(reset)}`,
+            wallMs: Date.now() - startedAt,
+          };
+        }
+      }
+      commands.push(`gateway rpc chat.send ${JSON.stringify(sendParams)}`);
       const started = await context.runGatewayRpc("chat.send", sendParams, context, {
         timeoutMs: Math.min(waitTimeoutMs, 30_000),
       });
@@ -1534,6 +1552,7 @@ function resolveBehaviorEvalScenarioTurns(scenario) {
     return scenario.turns.map((turn) => ({
       sessionKey: typeof turn.sessionKey === "string" && turn.sessionKey ? turn.sessionKey : undefined,
       sessionSuffix: typeof turn.sessionSuffix === "string" && turn.sessionSuffix ? turn.sessionSuffix : undefined,
+      resetBefore: turn.resetBefore === true,
       message: String(turn.message ?? ""),
       expectText: typeof turn.expectText === "string" ? turn.expectText : undefined,
     }));
@@ -1546,6 +1565,7 @@ function resolveBehaviorEvalScenarioTurns(scenario) {
     },
     {
       sessionSuffix: scenario.recallScope === "cross-session" ? "recall" : undefined,
+      resetBefore: scenario.recallScope !== "cross-session",
       message: "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
       expectText: "blue-lantern-42",
     },

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1747,26 +1747,34 @@ function toBehaviorEvalScenarioStep(result) {
 
 async function waitForBehaviorEvalGatewayReady({ baseUrl, child, logs, timeoutMs }) {
   const startedAt = Date.now();
+  let lastHealth = "not checked";
   while (Date.now() - startedAt < timeoutMs) {
     if (child.exitCode !== null || child.signalCode !== null) {
       throw new Error(`gateway exited before readiness: ${logs()}`);
     }
-    for (const pathName of ["/readyz", "/healthz"]) {
-      try {
-        const response = await fetch(`${baseUrl}${pathName}`, {
-          method: "HEAD",
-          signal: AbortSignal.timeout(2_000),
-        });
-        if (response.ok) {
-          return;
-        }
-      } catch {
-        // Keep polling until timeout.
+    try {
+      const response = await fetch(`${baseUrl}/readyz`, {
+        method: "HEAD",
+        signal: AbortSignal.timeout(2_000),
+      });
+      if (response.ok) {
+        return;
       }
+    } catch {
+      // Keep polling until timeout.
+    }
+    try {
+      const response = await fetch(`${baseUrl}/healthz`, {
+        method: "HEAD",
+        signal: AbortSignal.timeout(2_000),
+      });
+      lastHealth = `${response.status} ${response.statusText}`.trim();
+    } catch (error) {
+      lastHealth = formatErrorForReport(error);
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
-  throw new Error(`gateway did not become ready: ${logs()}`);
+  throw new Error(`gateway did not become ready; last healthz=${lastHealth}: ${logs()}`);
 }
 
 function finalizeBehaviorEvalExecution({ plan, steps, workspace, port, keptTemp, token }) {

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -49,6 +49,7 @@ async function main() {
       keepTemp: args.keepTemp,
       timeoutMs: args.timeoutMs,
     });
+    process.exitCode = behaviorEvalExecutionExitCode(execution, plan.expectation.mode);
     await writeBehaviorEvalExecutionResult(execution, {
       resultsDir: args.resultsDir,
     });
@@ -225,7 +226,7 @@ export function resolveBehaviorEvalProfile({ profile, overrides = {} }) {
   if (overrides.openclawPath) {
     next.openclaw = {
       source: "path",
-      path: overrides.openclawPath,
+      path: path.resolve(overrides.openclawPath),
     };
   } else if (overrides.openclawVersion) {
     next.openclaw = {
@@ -407,6 +408,7 @@ export function renderBehaviorEvalMarkdown(plan) {
 
 export async function executeBehaviorEvalPlan(plan, options = {}) {
   validateBehaviorEvalExecutionRequest({ env: options.env });
+  validateBehaviorEvalRunner(plan);
   const workspace = options.workspace ?? (await createBehaviorEvalWorkspace());
   const ownsWorkspace = !options.workspace;
   const getFreePortFn = options.getFreePort ?? getFreePort;
@@ -581,6 +583,25 @@ function validateBehaviorEvalExecutionRequest({ env = process.env }) {
   if (env.CRABPOT_EXECUTE_BEHAVIOR !== "1") {
     throw new Error("behavior eval execution requires CRABPOT_EXECUTE_BEHAVIOR=1");
   }
+}
+
+function validateBehaviorEvalRunner(plan) {
+  if (plan.summary.runner !== "local") {
+    throw new Error(`behavior eval execution requires runner.execution=local; got ${plan.summary.runner}`);
+  }
+}
+
+export function behaviorEvalExecutionExitCode(execution, expectationMode) {
+  if (expectationMode === "report-only") {
+    return 0;
+  }
+  if (expectationMode === "must-pass") {
+    return execution.status === "pass" ? 0 : 1;
+  }
+  if (expectationMode === "known-failure") {
+    return execution.status === "expected-failure" ? 0 : 1;
+  }
+  return 1;
 }
 
 async function createBehaviorEvalWorkspace() {

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1277,14 +1277,19 @@ function extractBehaviorEvalRequestText(value) {
   return parts.join("\n");
 }
 
-function buildBehaviorEvalMockResponseText(inputText) {
+export function buildBehaviorEvalMockResponseText(inputText) {
   if (/remember.*crabpot_lcm_fact|crabpot_lcm_fact/iu.test(inputText)) {
     if (/what is crabpot_lcm_fact|recall.*crabpot_lcm_fact/iu.test(inputText)) {
-      return "blue-lantern-42";
+      return extractBehaviorEvalFactValue(inputText) ?? "I do not have that fact.";
     }
     return "remembered CRABPOT_LCM_FACT";
   }
   return "ok";
+}
+
+function extractBehaviorEvalFactValue(inputText) {
+  const match = inputText.match(/\bCRABPOT_LCM_FACT\s*(?:is|=|:)\s*([A-Za-z0-9._-]+)/iu);
+  return match?.[1]?.replace(/[.?!,;:]+$/u, "") ?? null;
 }
 
 function buildBehaviorEvalMockResponseEvents(text) {
@@ -1345,7 +1350,7 @@ async function runBehaviorEvalScenario(plan, context) {
   const stderr = [];
   for (const turn of turns) {
     const runId = `crabpot-${randomUUID()}`;
-    const waitTimeoutMs = Math.max(1, Math.min(context.timeoutMs, 120_000));
+    const waitTimeoutMs = Math.max(1, context.timeoutMs);
     const sendParams = {
       sessionKey,
       message: turn.message,
@@ -1521,7 +1526,7 @@ async function runBehaviorEvalGatewayRpc(method, params, context, options = {}) 
     context.gatewayRpcClient = await createBehaviorEvalGatewayRpcClient({
       url: `ws://127.0.0.1:${context.port}`,
       token: context.token,
-      timeoutMs: Math.min(context.timeoutMs, 120_000),
+      timeoutMs: context.timeoutMs,
     });
   }
   return await context.gatewayRpcClient.request(method, params, {

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1517,12 +1517,12 @@ function resolveBehaviorEvalScenarioTurns(scenario) {
   }
   return [
     {
-      sessionSuffix: "seed",
+      sessionSuffix: scenario.recallScope === "cross-session" ? "seed" : undefined,
       message: "Remember this exact test fact: CRABPOT_LCM_FACT is blue-lantern-42.",
       expectText: "remembered",
     },
     {
-      sessionSuffix: "recall",
+      sessionSuffix: scenario.recallScope === "cross-session" ? "recall" : undefined,
       message: "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
       expectText: "blue-lantern-42",
     },

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -624,6 +624,9 @@ async function prepareBehaviorEvalWorkspace(workspace) {
     mkdir(workspace.homeDir, { recursive: true }),
     mkdir(resolveBehaviorEvalWorkspaceDir(workspace), { recursive: true }),
     mkdir(workspace.stateDir, { recursive: true }),
+    mkdir(path.join(workspace.stateDir, "appdata"), { recursive: true }),
+    mkdir(path.join(workspace.stateDir, "local-appdata"), { recursive: true }),
+    mkdir(path.join(workspace.tempRoot, "npm-cache"), { recursive: true }),
     mkdir(path.dirname(workspace.configPath), { recursive: true }),
     mkdir(workspace.xdgCacheHome, { recursive: true }),
     mkdir(workspace.xdgConfigHome, { recursive: true }),
@@ -723,8 +726,11 @@ function resolveBehaviorEvalNpmUserConfig(workspace) {
 
 function buildBehaviorEvalRuntimeEnv({ baseEnv = process.env, port, token, workspace }) {
   return {
-    ...baseEnv,
+    ...buildBehaviorEvalBaseEnv(baseEnv),
     HOME: workspace.homeDir,
+    USERPROFILE: workspace.homeDir,
+    APPDATA: path.join(workspace.stateDir, "appdata"),
+    LOCALAPPDATA: path.join(workspace.stateDir, "local-appdata"),
     OPENCLAW_HOME: workspace.homeDir,
     OPENCLAW_CONFIG_PATH: workspace.configPath,
     OPENCLAW_STATE_DIR: workspace.stateDir,
@@ -739,12 +745,33 @@ function buildBehaviorEvalRuntimeEnv({ baseEnv = process.env, port, token, works
     OPENCLAW_TEST_FAST: "1",
     NPM_CONFIG_USERCONFIG: resolveBehaviorEvalNpmUserConfig(workspace),
     npm_config_userconfig: resolveBehaviorEvalNpmUserConfig(workspace),
+    NPM_CONFIG_CACHE: path.join(workspace.tempRoot, "npm-cache"),
+    npm_config_cache: path.join(workspace.tempRoot, "npm-cache"),
     NPM_CONFIG_BEFORE: "",
     npm_config_before: "",
     XDG_CACHE_HOME: workspace.xdgCacheHome,
     XDG_CONFIG_HOME: workspace.xdgConfigHome,
     XDG_DATA_HOME: workspace.xdgDataHome,
   };
+}
+
+function buildBehaviorEvalBaseEnv(baseEnv) {
+  const allowed = [
+    "PATH",
+    "Path",
+    "SystemRoot",
+    "WINDIR",
+    "ComSpec",
+    "PATHEXT",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+  ];
+  return Object.fromEntries(
+    allowed
+      .filter((key) => typeof baseEnv?.[key] === "string" && baseEnv[key].length > 0)
+      .map((key) => [key, baseEnv[key]]),
+  );
 }
 
 async function writeBehaviorEvalConfig({ plan, workspace, context }) {
@@ -1896,14 +1923,14 @@ function formatOpenClawTarget(openclaw) {
 
 function openclawInvocation(openclaw) {
   if (openclaw.source === "npm") {
-    return `npm exec --yes --package=openclaw@${openclaw.version} -- openclaw`;
+    return `npm exec --yes --package=${shellQuote(`openclaw@${openclaw.version}`)} -- openclaw`;
   }
   return `node ${shellQuote(path.join(openclaw.path, "dist", "index.js"))}`;
 }
 
 function formatPluginInstallSpec(plugin) {
   if (plugin.source === "npm") {
-    return `npm:${plugin.spec}`;
+    return shellQuote(`npm:${plugin.spec}`);
   }
   if (plugin.source === "fixture") {
     return fixtureInstallToken(plugin.fixture);
@@ -1913,6 +1940,10 @@ function formatPluginInstallSpec(plugin) {
 
 function normalizeNpmPluginSpec(spec) {
   return spec.startsWith("npm:") ? spec.slice("npm:".length) : spec;
+}
+
+function isSafeNpmCoordinate(value) {
+  return /^[A-Za-z0-9_./:@+-]+$/.test(value);
 }
 
 function fixtureInstallToken(fixture) {
@@ -1966,6 +1997,8 @@ function validateBehaviorEvalProfile(profile, label) {
   } else if (profile.openclaw.source === "npm") {
     if (typeof profile.openclaw.version !== "string" || profile.openclaw.version.trim().length === 0) {
       errors.push("openclaw.version must be set for npm source");
+    } else if (!isSafeNpmCoordinate(profile.openclaw.version)) {
+      errors.push("openclaw.version must be an npm version or dist-tag without shell metacharacters");
     }
   } else if (profile.openclaw.source === "path") {
     if (typeof profile.openclaw.path !== "string" || profile.openclaw.path.trim().length === 0) {
@@ -1986,6 +2019,8 @@ function validateBehaviorEvalProfile(profile, label) {
       }
       if (plugin.source === "npm" && (typeof plugin.spec !== "string" || plugin.spec.trim().length === 0)) {
         errors.push(`${plugin.id}: plugin spec must be set`);
+      } else if (plugin.source === "npm" && !isSafeNpmCoordinate(plugin.spec)) {
+        errors.push(`${plugin.id}: plugin spec must be an npm package spec without shell metacharacters`);
       }
       if (plugin.source === "fixture" && !/^[a-z0-9][a-z0-9-]*$/.test(plugin.fixture ?? "")) {
         errors.push(`${plugin.id}: plugin fixture must be kebab-case`);

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -296,10 +296,11 @@ export function buildBehaviorEvalPlan({ profile, scenario }) {
     category: profile.category,
     scenario,
     expectation: cloneJson(profile.expectation),
+    plugins: cloneJson(profile.plugins),
     expectedFailureClasses: [...(profile.expectation.failureClasses ?? [])],
     summary: {
       openclaw,
-      plugins: profile.plugins.map((plugin) => plugin.spec).join(", "),
+      plugins: profile.plugins.map(formatPluginSummary).join(", "),
       runner: profile.runner.execution,
       providerMode: profile.runner.providerMode,
       timeoutMs: profile.runner.timeoutMs,
@@ -430,6 +431,7 @@ export async function executeBehaviorEvalPlan(plan, options = {}) {
     token,
     timeoutMs,
     workspace,
+    pluginFixtures: await createBehaviorEvalPluginFixtures({ plan, workspace }),
     openclawCommand: resolveOpenClawCommandFromPlan(plan),
     providerBaseUrl: undefined,
     runCommand,
@@ -607,6 +609,87 @@ async function prepareBehaviorEvalWorkspace(workspace) {
     mkdir(workspace.xdgDataHome, { recursive: true }),
     writeFile(resolveBehaviorEvalNpmUserConfig(workspace), "", "utf8"),
   ]);
+}
+
+async function createBehaviorEvalPluginFixtures({ plan, workspace }) {
+  const fixtures = {};
+  for (const plugin of plan.plugins ?? []) {
+    if (plugin.source !== "fixture") {
+      continue;
+    }
+    fixtures[plugin.fixture] = await writeBehaviorEvalPluginFixture({ fixture: plugin.fixture, workspace });
+  }
+  return fixtures;
+}
+
+async function writeBehaviorEvalPluginFixture({ fixture, workspace }) {
+  if (fixture !== "broken-context-engine") {
+    throw new Error(`unknown behavior eval plugin fixture: ${fixture}`);
+  }
+  const fixtureDir = path.join(workspace.tempRoot, "fixtures", fixture);
+  await mkdir(fixtureDir, { recursive: true });
+  await Promise.all([
+    writeFile(
+      path.join(fixtureDir, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@crabpot/broken-context-engine-fixture",
+          version: "0.0.0",
+          private: true,
+          type: "module",
+          main: "index.js",
+          openclaw: {
+            extensions: ["./index.js"],
+            runtimeExtensions: ["./index.js"],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    ),
+    writeFile(
+      path.join(fixtureDir, "openclaw.plugin.json"),
+      `${JSON.stringify(
+        {
+          id: "broken-context-engine",
+          name: "Broken Context Engine Fixture",
+          version: "0.0.0",
+          enabledByDefault: false,
+          kind: "context-engine",
+          activation: {
+            onCapabilities: ["context-engine"],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    ),
+    writeFile(
+      path.join(fixtureDir, "index.js"),
+      [
+        "export const plugin = {",
+        '  id: "broken-context-engine",',
+        "  register(api) {",
+        '    api.registerContextEngine("broken-context-engine", () => ({',
+        '      info: { id: "broken-context-engine", name: "Broken Context Engine Fixture", ownsCompaction: true },',
+        "      ingest: async () => ({ ingested: true }),",
+        "    }));",
+        "  },",
+        "};",
+        "",
+        "export function register(api) {",
+        "  plugin.register(api);",
+        "}",
+        "",
+        "export default plugin;",
+        "",
+      ].join("\n"),
+      "utf8",
+    ),
+  ]);
+  return fixtureDir;
 }
 
 function resolveBehaviorEvalWorkspaceDir(workspace) {
@@ -1286,6 +1369,17 @@ async function runBehaviorEvalScenario(plan, context) {
       };
     }
   }
+  const healthFailure = await runBehaviorEvalScenarioHealthChecks({
+    plan,
+    context,
+    commands,
+    stdout,
+    stderr,
+    startedAt,
+  });
+  if (healthFailure) {
+    return healthFailure;
+  }
   return {
     status: "pass",
     exitCode: 0,
@@ -1294,6 +1388,65 @@ async function runBehaviorEvalScenario(plan, context) {
     stderr: stderr.join("\n"),
     wallMs: Date.now() - startedAt,
   };
+}
+
+async function runBehaviorEvalScenarioHealthChecks({ plan, context, commands, stdout, stderr, startedAt }) {
+  const checks = Array.isArray(plan.scenario.healthChecks) ? plan.scenario.healthChecks : [];
+  for (const check of checks) {
+    const method = typeof check.method === "string" && check.method ? check.method : "health";
+    const params = check.params && typeof check.params === "object" ? check.params : { probe: true };
+    commands.push(`gateway rpc ${method} ${JSON.stringify(params)}`);
+    try {
+      const payload = await context.runGatewayRpc(method, params, context, {
+        timeoutMs: Math.min(context.timeoutMs, 30_000),
+      });
+      stdout.push(`${method} ${JSON.stringify(payload)}`);
+      const failure = evaluateBehaviorEvalHealthCheck(check, payload);
+      if (failure) {
+        return {
+          status: "fail",
+          exitCode: 1,
+          command: commands.join("\n"),
+          stdout: stdout.join("\n"),
+          stderr: `${stderr.join("\n")}\n${failure}`,
+          wallMs: Date.now() - startedAt,
+        };
+      }
+    } catch (error) {
+      return {
+        status: "fail",
+        exitCode: 1,
+        command: commands.join("\n"),
+        stdout: stdout.join("\n"),
+        stderr: `${stderr.join("\n")}\n${formatErrorForReport(error)}`,
+        wallMs: Date.now() - startedAt,
+      };
+    }
+  }
+  return null;
+}
+
+function evaluateBehaviorEvalHealthCheck(check, payload) {
+  const expectedQuarantines = Array.isArray(check.expect?.contextEngineQuarantines)
+    ? check.expect.contextEngineQuarantines
+    : [];
+  if (expectedQuarantines.length === 0) {
+    return null;
+  }
+  const quarantines = Array.isArray(payload?.contextEngineQuarantines)
+    ? payload.contextEngineQuarantines
+    : [];
+  for (const expected of expectedQuarantines) {
+    const match = quarantines.find((quarantine) =>
+      (!expected.pluginId || quarantine.pluginId === expected.pluginId) &&
+      (!expected.engineId || quarantine.engineId === expected.engineId) &&
+      (!expected.reasonIncludes || String(quarantine.reason ?? "").includes(expected.reasonIncludes))
+    );
+    if (!match) {
+      return `context-engine-quarantine-missing: expected ${JSON.stringify(expected)} in ${JSON.stringify(quarantines)}`;
+    }
+  }
+  return null;
 }
 
 function resolveBehaviorEvalScenarioTurns(scenario) {
@@ -1628,9 +1781,13 @@ function splitCommands(value) {
 }
 
 function materializeBehaviorEvalCommand(command, context) {
-  return command
+  let materialized = command
     .replaceAll("<free-port>", String(context.port))
     .replaceAll("<token>", shellQuote(context.token));
+  for (const [fixture, fixturePath] of Object.entries(context.pluginFixtures ?? {})) {
+    materialized = materialized.replaceAll(fixtureInstallToken(fixture), shellQuote(fixturePath));
+  }
+  return materialized;
 }
 
 function resolveOpenClawCommandFromPlan(plan) {
@@ -1671,6 +1828,9 @@ function classifyBehaviorEvalFailure(output) {
   }
   if (text.includes("memory-recall-mismatch")) {
     return "memory-recall-mismatch";
+  }
+  if (text.includes("context-engine-quarantine-missing")) {
+    return "context-engine-quarantine-missing";
   }
   if (text.includes("gateway")) {
     return "gateway-unavailable";
@@ -1724,11 +1884,28 @@ function formatPluginInstallSpec(plugin) {
   if (plugin.source === "npm") {
     return `npm:${plugin.spec}`;
   }
+  if (plugin.source === "fixture") {
+    return fixtureInstallToken(plugin.fixture);
+  }
   throw new Error(`unsupported plugin source for ${plugin.id}: ${plugin.source}`);
 }
 
 function normalizeNpmPluginSpec(spec) {
   return spec.startsWith("npm:") ? spec.slice("npm:".length) : spec;
+}
+
+function fixtureInstallToken(fixture) {
+  return `__CRABPOT_BEHAVIOR_PLUGIN_FIXTURE_${fixture}__`;
+}
+
+function formatPluginSummary(plugin) {
+  if (plugin.source === "npm") {
+    return plugin.spec;
+  }
+  if (plugin.source === "fixture") {
+    return `fixture:${plugin.fixture}`;
+  }
+  return `${plugin.source}:${plugin.id}`;
 }
 
 function plannedStatusForExpectation(mode) {
@@ -1783,11 +1960,14 @@ function validateBehaviorEvalProfile(profile, label) {
       if (!/^[a-z0-9][a-z0-9-]*$/.test(plugin.id ?? "")) {
         errors.push("plugin id must be kebab-case");
       }
-      if (plugin.source !== "npm") {
-        errors.push(`${plugin.id}: plugin source must be npm`);
+      if (!["npm", "fixture"].includes(plugin.source)) {
+        errors.push(`${plugin.id}: plugin source must be npm or fixture`);
       }
-      if (typeof plugin.spec !== "string" || plugin.spec.trim().length === 0) {
+      if (plugin.source === "npm" && (typeof plugin.spec !== "string" || plugin.spec.trim().length === 0)) {
         errors.push(`${plugin.id}: plugin spec must be set`);
+      }
+      if (plugin.source === "fixture" && !/^[a-z0-9][a-z0-9-]*$/.test(plugin.fixture ?? "")) {
+        errors.push(`${plugin.id}: plugin fixture must be kebab-case`);
       }
     }
   }

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -249,6 +249,9 @@ export function resolveBehaviorEvalProfile({ profile, overrides = {} }) {
       ...next.expectation,
       mode: overrides.expectationMode,
     };
+    if (overrides.expectationMode !== "known-failure") {
+      delete next.expectation.failureClasses;
+    }
   }
   if (overrides.runnerExecution) {
     next.runner = {
@@ -272,6 +275,7 @@ export function buildBehaviorEvalPlan({ profile, scenario }) {
       plugin.id,
       {
         enabled: true,
+        ...(plugin.config ? { config: cloneJson(plugin.config) } : {}),
       },
     ]),
   );
@@ -1307,18 +1311,48 @@ function extractBehaviorEvalRequestText(value) {
 }
 
 export function buildBehaviorEvalMockResponseText(inputText) {
+  if (isBehaviorEvalSummarizationRequest(inputText)) {
+    const fact = extractBehaviorEvalFactValue(inputText);
+    return fact ? `CRABPOT_LCM_FACT is ${fact}.` : "No CRABPOT_LCM_FACT was present.";
+  }
+  if (/Say one neutral filler response/iu.test(inputText)) {
+    return "ok";
+  }
   if (/remember.*crabpot_lcm_fact|crabpot_lcm_fact/iu.test(inputText)) {
     if (/what is crabpot_lcm_fact|recall.*crabpot_lcm_fact/iu.test(inputText)) {
-      return extractBehaviorEvalFactValue(inputText) ?? "I do not have that fact.";
+      return extractBehaviorEvalContextFactValue(inputText) ?? "I do not have that fact.";
+    }
+    if (/reply.*crabpot_lcm_fact|exact memory marker/iu.test(inputText)) {
+      const fact = extractBehaviorEvalFactValue(inputText);
+      return fact ? `CRABPOT_LCM_FACT is ${fact}.` : "CRABPOT_LCM_FACT is missing.";
     }
     return "remembered CRABPOT_LCM_FACT";
   }
   return "ok";
 }
 
+function isBehaviorEvalSummarizationRequest(inputText) {
+  return (
+    /context-compaction summarization engine/iu.test(inputText) ||
+    /You summarize a SEGMENT of an OpenClaw conversation/iu.test(inputText) ||
+    /<conversation_segment>/iu.test(inputText)
+  );
+}
+
 function extractBehaviorEvalFactValue(inputText) {
   const match = inputText.match(/\bCRABPOT_LCM_FACT\s*(?:is|=|:)\s*([A-Za-z0-9._-]+)/iu);
   return match?.[1]?.replace(/[.?!,;:]+$/u, "") ?? null;
+}
+
+function extractBehaviorEvalContextFactValue(inputText) {
+  const contextBlocks = inputText.match(/<(?:summary|focus_brief)\b[\s\S]*?<\/(?:summary|focus_brief)>/giu) ?? [];
+  for (const block of contextBlocks) {
+    const value = extractBehaviorEvalFactValue(block);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function buildBehaviorEvalMockResponseEvents(text) {
@@ -1377,7 +1411,7 @@ async function runBehaviorEvalScenario(plan, context) {
   const commands = [];
   const stdout = [];
   const stderr = [];
-  for (const turn of turns) {
+  for (const [turnIndex, turn] of turns.entries()) {
     const sessionKey = turn.sessionKey ?? `${baseSessionKey}:${turn.sessionSuffix ?? "default"}`;
     const runId = `crabpot-${randomUUID()}`;
     const waitTimeoutMs = Math.max(1, context.timeoutMs);
@@ -1432,12 +1466,14 @@ async function runBehaviorEvalScenario(plan, context) {
       stdout.push(`chat.history ${JSON.stringify(history)}`);
       const latestAssistantText = extractLatestBehaviorEvalAssistantText(history);
       if (turn.expectText && !latestAssistantText.includes(turn.expectText)) {
+        const mismatchClass =
+          turnIndex === turns.length - 1 ? "memory-recall-mismatch" : "behavior-turn-mismatch";
         return {
           status: "fail",
           exitCode: 1,
           command: commands.join("\n"),
           stdout: stdout.join("\n"),
-          stderr: `${stderr.join("\n")}\nmemory-recall-mismatch: expected latest assistant message to contain ${turn.expectText}; got ${latestAssistantText || "<empty>"}`,
+          stderr: `${stderr.join("\n")}\n${mismatchClass}: expected turn ${turnIndex + 1} latest assistant message to contain ${turn.expectText}; got ${latestAssistantText || "<empty>"}`,
           wallMs: Date.now() - startedAt,
         };
       }
@@ -1806,7 +1842,10 @@ async function waitForBehaviorEvalGatewayReady({ baseUrl, child, logs, timeoutMs
 function finalizeBehaviorEvalExecution({ plan, steps, workspace, port, keptTemp, token }) {
   const failed = steps.find((step) => step.status === "fail");
   const failureClass = failed?.failureClass;
-  const expectedFailure = failureClass && plan.expectedFailureClasses.includes(failureClass);
+  const expectedFailure =
+    plan.expectation.mode === "known-failure" &&
+    failureClass &&
+    plan.expectedFailureClasses.includes(failureClass);
   const status = failed
     ? expectedFailure
       ? "expected-failure"
@@ -1923,6 +1962,9 @@ function classifyBehaviorEvalFailure(output) {
   }
   if (text.includes("memory-recall-mismatch")) {
     return "memory-recall-mismatch";
+  }
+  if (text.includes("behavior-turn-mismatch")) {
+    return "behavior-turn-mismatch";
   }
   if (text.includes("context-engine-quarantine-missing")) {
     return "context-engine-quarantine-missing";
@@ -2071,6 +2113,9 @@ function validateBehaviorEvalProfile(profile, label) {
       }
       if (plugin.source === "fixture" && !/^[a-z0-9][a-z0-9-]*$/.test(plugin.fixture ?? "")) {
         errors.push(`${plugin.id}: plugin fixture must be kebab-case`);
+      }
+      if (plugin.config !== undefined && (!plugin.config || typeof plugin.config !== "object" || Array.isArray(plugin.config))) {
+        errors.push(`${plugin.id}: plugin config must be an object`);
       }
     }
   }

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -574,8 +574,31 @@ export async function executeBehaviorEvalPlan(plan, options = {}) {
       await providerHandle.stop().catch(() => {});
     }
     if (ownsWorkspace && !options.keepTemp) {
-      await rm(workspace.tempRoot, { recursive: true, force: true });
+      await removeBehaviorEvalTempRoot(workspace.tempRoot);
     }
+  }
+}
+
+export async function removeBehaviorEvalTempRoot(
+  tempRoot,
+  { remove = rm, warn = (message) => process.stderr.write(`${message}\n`) } = {},
+) {
+  try {
+    await remove(tempRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    });
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return;
+    }
+    if (["ENOTEMPTY", "EBUSY", "EPERM"].includes(error?.code)) {
+      warn(`behavior eval temp cleanup skipped after process teardown: ${formatErrorForReport(error)}`);
+      return;
+    }
+    throw error;
   }
 }
 

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1017,19 +1017,22 @@ async function runBehaviorEvalStep({ id, command, context, runCommand }) {
   };
 }
 
-function runBehaviorEvalCommand(command, context) {
+export function runBehaviorEvalCommand(command, context) {
   return new Promise((resolve) => {
     const startedAt = Date.now();
     const stdout = [];
     const stderr = [];
+    let timedOut = false;
     const child = spawn(command, {
       cwd: context.workspace.tempRoot,
       env: context.env,
       shell: true,
+      detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
     });
     const timeout = setTimeout(() => {
-      child.kill("SIGKILL");
+      timedOut = true;
+      signalBehaviorEvalChildProcess(child, "SIGKILL", process.kill);
     }, context.timeoutMs);
     child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
     child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
@@ -1047,7 +1050,7 @@ function runBehaviorEvalCommand(command, context) {
       resolve({
         exitCode: signal ? 1 : (code ?? 1),
         stdout: Buffer.concat(stdout).toString("utf8"),
-        stderr: Buffer.concat(stderr).toString("utf8"),
+        stderr: `${Buffer.concat(stderr).toString("utf8")}${timedOut ? "\ncommand timed out" : ""}`,
         wallMs: Date.now() - startedAt,
       });
     });
@@ -1344,11 +1347,12 @@ function buildBehaviorEvalMockResponseEvents(text) {
 async function runBehaviorEvalScenario(plan, context) {
   const startedAt = Date.now();
   const turns = resolveBehaviorEvalScenarioTurns(plan.scenario);
-  const sessionKey = `agent:qa:discord:channel:crabpot-${plan.scenario.id}`;
+  const baseSessionKey = `agent:qa:discord:channel:crabpot-${plan.scenario.id}`;
   const commands = [];
   const stdout = [];
   const stderr = [];
   for (const turn of turns) {
+    const sessionKey = turn.sessionKey ?? `${baseSessionKey}:${turn.sessionSuffix ?? "default"}`;
     const runId = `crabpot-${randomUUID()}`;
     const waitTimeoutMs = Math.max(1, context.timeoutMs);
     const sendParams = {
@@ -1505,16 +1509,20 @@ function evaluateBehaviorEvalHealthCheck(check, payload) {
 function resolveBehaviorEvalScenarioTurns(scenario) {
   if (Array.isArray(scenario.turns) && scenario.turns.length > 0) {
     return scenario.turns.map((turn) => ({
+      sessionKey: typeof turn.sessionKey === "string" && turn.sessionKey ? turn.sessionKey : undefined,
+      sessionSuffix: typeof turn.sessionSuffix === "string" && turn.sessionSuffix ? turn.sessionSuffix : undefined,
       message: String(turn.message ?? ""),
       expectText: typeof turn.expectText === "string" ? turn.expectText : undefined,
     }));
   }
   return [
     {
+      sessionSuffix: "seed",
       message: "Remember this exact test fact: CRABPOT_LCM_FACT is blue-lantern-42.",
       expectText: "remembered",
     },
     {
+      sessionSuffix: "recall",
       message: "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
       expectText: "blue-lantern-42",
     },

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -798,6 +798,9 @@ function buildBehaviorEvalBaseEnv(baseEnv) {
 }
 
 async function writeBehaviorEvalConfig({ plan, workspace, context }) {
+  // Plugin install records are written by `openclaw plugins install` under the
+  // isolated state dir. This config only selects/enables the already-installed
+  // plugin ids before the gateway starts.
   let config = {
     plugins: plan.configPatch.plugins,
     agents: {

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1385,26 +1385,8 @@ async function runBehaviorEvalScenario(plan, context) {
       timeoutMs: waitTimeoutMs,
       idempotencyKey: runId,
     };
+    commands.push(`gateway rpc chat.send ${JSON.stringify(sendParams)}`);
     try {
-      if (turn.resetBefore) {
-        const resetParams = { key: sessionKey, reason: "reset" };
-        commands.push(`gateway rpc sessions.reset ${JSON.stringify(resetParams)}`);
-        const reset = await context.runGatewayRpc("sessions.reset", resetParams, context, {
-          timeoutMs: Math.min(waitTimeoutMs, 30_000),
-        });
-        stdout.push(`sessions.reset ${JSON.stringify(reset)}`);
-        if (reset?.status && reset.status !== "ok") {
-          return {
-            status: "fail",
-            exitCode: 1,
-            command: commands.join("\n"),
-            stdout: stdout.join("\n"),
-            stderr: `sessions.reset returned ${JSON.stringify(reset)}`,
-            wallMs: Date.now() - startedAt,
-          };
-        }
-      }
-      commands.push(`gateway rpc chat.send ${JSON.stringify(sendParams)}`);
       const started = await context.runGatewayRpc("chat.send", sendParams, context, {
         timeoutMs: Math.min(waitTimeoutMs, 30_000),
       });
@@ -1552,7 +1534,6 @@ function resolveBehaviorEvalScenarioTurns(scenario) {
     return scenario.turns.map((turn) => ({
       sessionKey: typeof turn.sessionKey === "string" && turn.sessionKey ? turn.sessionKey : undefined,
       sessionSuffix: typeof turn.sessionSuffix === "string" && turn.sessionSuffix ? turn.sessionSuffix : undefined,
-      resetBefore: turn.resetBefore === true,
       message: String(turn.message ?? ""),
       expectText: typeof turn.expectText === "string" ? turn.expectText : undefined,
     }));
@@ -1565,7 +1546,6 @@ function resolveBehaviorEvalScenarioTurns(scenario) {
     },
     {
       sessionSuffix: scenario.recallScope === "cross-session" ? "recall" : undefined,
-      resetBefore: scenario.recallScope !== "cross-session",
       message: "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
       expectText: "blue-lantern-42",
     },

--- a/scripts/run-static-suite.mjs
+++ b/scripts/run-static-suite.mjs
@@ -55,6 +55,7 @@ export function buildStaticSuiteSteps({
     ["node", ["scripts/generate-report.mjs", "--check", ...openclawArgs], fixtureEnv],
     ["node", ["scripts/capture-contracts.mjs", "--check", ...openclawArgs], fixtureEnv],
     ["node", ["scripts/synthetic-probes.mjs", "--check", ...openclawArgs], fixtureEnv],
+    ["node", ["scripts/behavior-eval.mjs", "--check"], fixtureEnv],
     ["node", ["scripts/cold-import-readiness.mjs", "--check", ...openclawArgs], fixtureEnv],
     ["node", ["scripts/workspace-plan.mjs", "--check", ...openclawArgs], fixtureEnv],
     ["node", ["scripts/platform-probes.mjs", "--check", ...openclawArgs], fixtureEnv],

--- a/scripts/run-static-suite.mjs
+++ b/scripts/run-static-suite.mjs
@@ -55,7 +55,7 @@ export function buildStaticSuiteSteps({
     ["node", ["scripts/generate-report.mjs", "--check", ...openclawArgs], fixtureEnv],
     ["node", ["scripts/capture-contracts.mjs", "--check", ...openclawArgs], fixtureEnv],
     ["node", ["scripts/synthetic-probes.mjs", "--check", ...openclawArgs], fixtureEnv],
-    ["node", ["scripts/behavior-eval.mjs", "--check"], fixtureEnv],
+    ...(openclawArgs.length === 0 ? [["node", ["scripts/behavior-eval.mjs", "--check"], fixtureEnv]] : []),
     ["node", ["scripts/cold-import-readiness.mjs", "--check", ...openclawArgs], fixtureEnv],
     ["node", ["scripts/workspace-plan.mjs", "--check", ...openclawArgs], fixtureEnv],
     ["node", ["scripts/platform-probes.mjs", "--check", ...openclawArgs], fixtureEnv],

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -121,6 +121,24 @@ test("behavior eval loader reads the default forward LCM release gate", async ()
   assert.match(plan.summary.plugins, /@martian-engineering\/lossless-claw@latest/);
 });
 
+test("behavior eval loader reads the context-engine quarantine release gate", async () => {
+  const profile = await loadBehaviorEvalProfile("forward-context-engine-quarantine-gate");
+  const loadedScenario = await loadBehaviorEvalScenario(profile.scenario);
+  const plan = buildBehaviorEvalPlan({ profile, scenario: loadedScenario });
+
+  assert.equal(plan.profileId, "forward-context-engine-quarantine-gate");
+  assert.equal(plan.scenario.id, "context-engine-quarantine-fallback");
+  assert.equal(plan.expectation.mode, "must-pass");
+  assert.equal(plan.summary.openclaw, "openclaw@latest");
+  assert.equal(plan.summary.plugins, "fixture:broken-context-engine");
+  assert.deepEqual(plan.configPatch.plugins.slots, { contextEngine: "broken-context-engine" });
+  assert.ok(
+    plan.steps.some((step) =>
+      step.command?.includes("__CRABPOT_BEHAVIOR_PLUGIN_FIXTURE_broken-context-engine__"),
+    ),
+  );
+});
+
 test("behavior eval executor requires explicit isolated execution opt-in", async () => {
   const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
 
@@ -376,6 +394,125 @@ test("behavior eval executor fails recall when the token only appears in earlier
     assert.equal(result.failureClass, "memory-recall-mismatch");
     assert.equal(result.workspace.kept, false);
     assert.match(result.steps.at(-2).stderr, /latest assistant/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("behavior eval executor passes when a broken context engine is downgraded and reported", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const profile = await loadBehaviorEvalProfile("forward-context-engine-quarantine-gate");
+    const loadedScenario = await loadBehaviorEvalScenario(profile.scenario);
+    const plan = buildBehaviorEvalPlan({ profile, scenario: loadedScenario });
+    const commands = [];
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19794,
+      runCommand: async (command) => {
+        commands.push(command);
+        return { exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 };
+      },
+      startGateway: async (command) => {
+        commands.push(command);
+        return { status: "pass", stdout: "ready", stderr: "", wallMs: 1 };
+      },
+      startProvider: async () => ({
+        baseUrl: "http://127.0.0.1:45682",
+        stop: async () => {},
+      }),
+      runGatewayRpc: async (method, params) => {
+        if (method === "chat.send") {
+          return { status: "started", runId: params.idempotencyKey };
+        }
+        if (method === "agent.wait") {
+          return { status: "ok", runId: params.runId };
+        }
+        if (method === "chat.history") {
+          return { messages: [{ role: "assistant", text: "ok" }] };
+        }
+        if (method === "health") {
+          return {
+            contextEngineQuarantines: [
+              {
+                pluginId: "broken-context-engine",
+                engineId: "broken-context-engine",
+                reason: "Context engine \"broken-context-engine\" factory returned an invalid ContextEngine: missing assemble(), missing compact().",
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected rpc method ${method}`);
+      },
+    });
+
+    assert.equal(result.status, "pass");
+    assert.equal(result.failureClass, null);
+    assert.ok(commands.some((command) => command.includes(path.join(tempRoot, "fixtures", "broken-context-engine"))));
+    assert.match(
+      await readFile(path.join(tempRoot, "fixtures", "broken-context-engine", "index.js"), "utf8"),
+      /registerContextEngine/,
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("behavior eval executor fails when broken context engine quarantine is not reported", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const profile = await loadBehaviorEvalProfile("forward-context-engine-quarantine-gate");
+    const loadedScenario = await loadBehaviorEvalScenario(profile.scenario);
+    const plan = buildBehaviorEvalPlan({ profile, scenario: loadedScenario });
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19795,
+      runCommand: async () => ({ exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 }),
+      startGateway: async () => ({ status: "pass", stdout: "ready", stderr: "", wallMs: 1 }),
+      startProvider: async () => ({
+        baseUrl: "http://127.0.0.1:45683",
+        stop: async () => {},
+      }),
+      runGatewayRpc: async (method, params) => {
+        if (method === "chat.send") {
+          return { status: "started", runId: params.idempotencyKey };
+        }
+        if (method === "agent.wait") {
+          return { status: "ok", runId: params.runId };
+        }
+        if (method === "chat.history") {
+          return { messages: [{ role: "assistant", text: "ok" }] };
+        }
+        if (method === "health") {
+          return { contextEngineQuarantines: [] };
+        }
+        throw new Error(`unexpected rpc method ${method}`);
+      },
+    });
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.failureClass, "context-engine-quarantine-missing");
+    assert.match(result.steps.at(-2).stderr, /context-engine-quarantine-missing/);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -13,6 +13,7 @@ import {
   loadBehaviorEvalScenario,
   renderBehaviorEvalMarkdown,
   resolveBehaviorEvalProfile,
+  runBehaviorEvalCommand,
   stopBehaviorEvalChildProcess,
 } from "../scripts/behavior-eval.mjs";
 
@@ -326,7 +327,8 @@ test("behavior eval executor records isolated setup, config, and gateway readine
       "agent.wait",
       "chat.history",
     ]);
-    assert.equal(rpcCalls[0].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn");
+    assert.equal(rpcCalls[0].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:seed");
+    assert.equal(rpcCalls[3].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:recall");
     assert.match(rpcCalls[0].params.message, /CRABPOT_LCM_FACT/);
     assert.equal(rpcCalls[1].params.runId, rpcCalls[0].params.idempotencyKey);
     assert.equal(rpcCalls[1].params.timeoutMs, 900000);
@@ -680,4 +682,23 @@ test("behavior eval gateway stop waits for the child process to exit", async () 
   assert.equal(child.exitCode, null);
   await stopPromise;
   assert.equal(child.exitCode, 0);
+});
+
+test("behavior eval shell command timeout reports and terminates the command group", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const result = await runBehaviorEvalCommand(
+      `"${process.execPath}" -e "setInterval(() => {}, 1000)"`,
+      {
+        workspace: { tempRoot },
+        env: process.env,
+        timeoutMs: 20,
+      },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /command timed out/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -21,6 +21,7 @@ const scenario = {
   id: "lcm-basic-memory-turn",
   category: "context-engine",
   description: "Install LCM, select it as the context engine, and run one memory-shaped turn.",
+  recallScope: "cross-session",
   checks: [
     { id: "install", description: "LCM package installs" },
     { id: "gateway-load", description: "Gateway starts with LCM selected" },
@@ -205,7 +206,8 @@ test("behavior eval loader reads the context-engine quarantine release gate", as
 
   assert.equal(plan.profileId, "forward-context-engine-quarantine-gate");
   assert.equal(plan.scenario.id, "context-engine-quarantine-fallback");
-  assert.equal(plan.expectation.mode, "must-pass");
+  assert.equal(plan.expectation.mode, "known-failure");
+  assert.deepEqual(plan.expectedFailureClasses, ["context-engine-quarantine-missing"]);
   assert.equal(plan.summary.openclaw, "openclaw@latest");
   assert.equal(plan.summary.plugins, "fixture:broken-context-engine");
   assert.deepEqual(plan.configPatch.plugins.slots, { contextEngine: "broken-context-engine" });
@@ -500,7 +502,7 @@ test("behavior eval executor fails recall when the token only appears in earlier
   }
 });
 
-test("behavior eval executor passes when a broken context engine is downgraded and reported", async () => {
+test("behavior eval executor flags quarantine health as unexpected pass while tracking latest", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
   try {
     const profile = await loadBehaviorEvalProfile("forward-context-engine-quarantine-gate");
@@ -557,7 +559,7 @@ test("behavior eval executor passes when a broken context engine is downgraded a
       },
     });
 
-    assert.equal(result.status, "pass");
+    assert.equal(result.status, "unexpected-pass");
     assert.equal(result.failureClass, null);
     assert.ok(commands.some((command) => command.includes(path.join(tempRoot, "fixtures", "broken-context-engine"))));
     assert.match(
@@ -569,7 +571,7 @@ test("behavior eval executor passes when a broken context engine is downgraded a
   }
 });
 
-test("behavior eval executor fails when broken context engine quarantine is not reported", async () => {
+test("behavior eval executor tracks missing quarantine health as expected failure", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
   try {
     const profile = await loadBehaviorEvalProfile("forward-context-engine-quarantine-gate");
@@ -611,7 +613,7 @@ test("behavior eval executor fails when broken context engine quarantine is not 
       },
     });
 
-    assert.equal(result.status, "fail");
+    assert.equal(result.status, "expected-failure");
     assert.equal(result.failureClass, "context-engine-quarantine-missing");
     assert.match(result.steps.at(-2).stderr, /context-engine-quarantine-missing/);
   } finally {

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -11,6 +11,7 @@ import {
   executeBehaviorEvalPlan,
   loadBehaviorEvalProfile,
   loadBehaviorEvalScenario,
+  removeBehaviorEvalTempRoot,
   renderBehaviorEvalMarkdown,
   resolveBehaviorEvalProfile,
   runBehaviorEvalCommand,
@@ -703,4 +704,20 @@ test("behavior eval shell command timeout reports and terminates the command gro
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("behavior eval temp cleanup does not mask transient removal races", async () => {
+  const messages = [];
+  const error = new Error("directory not empty");
+  error.code = "ENOTEMPTY";
+
+  await removeBehaviorEvalTempRoot("/tmp/crabpot-behavior-test-race", {
+    remove: async () => {
+      throw error;
+    },
+    warn: (message) => messages.push(message),
+  });
+
+  assert.equal(messages.length, 1);
+  assert.match(messages[0], /cleanup skipped/);
 });

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -21,7 +21,7 @@ import {
 const scenario = {
   id: "lcm-basic-memory-turn",
   category: "context-engine",
-  description: "Install LCM, select it as the context engine, and recall after a session reset.",
+  description: "Install LCM, select it as the context engine, and run two memory-shaped turns.",
   recallScope: "same-session-key",
   checks: [
     { id: "install", description: "LCM package installs" },
@@ -304,9 +304,6 @@ test("behavior eval executor records isolated setup, config, and gateway readine
             ],
           };
         }
-        if (method === "sessions.reset") {
-          return { ok: true, key: params.key };
-        }
         throw new Error(`unexpected rpc method ${method}`);
       },
     });
@@ -329,15 +326,12 @@ test("behavior eval executor records isolated setup, config, and gateway readine
       "chat.send",
       "agent.wait",
       "chat.history",
-      "sessions.reset",
       "chat.send",
       "agent.wait",
       "chat.history",
     ]);
     assert.equal(rpcCalls[0].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
-    assert.equal(rpcCalls[3].params.key, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
-    assert.equal(rpcCalls[3].params.reason, "reset");
-    assert.equal(rpcCalls[4].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
+    assert.equal(rpcCalls[3].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
     assert.match(rpcCalls[0].params.message, /CRABPOT_LCM_FACT/);
     assert.equal(rpcCalls[1].params.runId, rpcCalls[0].params.idempotencyKey);
     assert.equal(rpcCalls[1].params.timeoutMs, 900000);
@@ -495,9 +489,6 @@ test("behavior eval executor fails recall when the token only appears in earlier
               },
             ],
           };
-        }
-        if (method === "sessions.reset") {
-          return { ok: true, key: params.key };
         }
         throw new Error(`unexpected rpc method ${method}`);
       },

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import {
+  behaviorEvalExecutionExitCode,
   buildBehaviorEvalPlan,
   executeBehaviorEvalPlan,
   loadBehaviorEvalProfile,
@@ -52,6 +53,16 @@ const historicalProfile = {
   },
 };
 
+function buildLocalPlan(profile, scenarioValue) {
+  return buildBehaviorEvalPlan({
+    profile: resolveBehaviorEvalProfile({
+      profile,
+      overrides: { runnerExecution: "local" },
+    }),
+    scenario: scenarioValue,
+  });
+}
+
 test("behavior eval planner builds the historical LCM repro steps", () => {
   const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
 
@@ -98,6 +109,26 @@ test("behavior eval profile resolver applies ad hoc version overrides", () => {
   assert.equal(resolved.runner.execution, "local");
 });
 
+test("behavior eval profile resolver absolutizes local OpenClaw paths", () => {
+  const resolved = resolveBehaviorEvalProfile({
+    profile: historicalProfile,
+    overrides: {
+      openclawPath: "../openclaw",
+    },
+  });
+
+  assert.equal(resolved.openclaw.source, "path");
+  assert.equal(resolved.openclaw.path, path.resolve("../openclaw"));
+});
+
+test("behavior eval exit code follows expectation contract", () => {
+  assert.equal(behaviorEvalExecutionExitCode({ status: "pass" }, "must-pass"), 0);
+  assert.equal(behaviorEvalExecutionExitCode({ status: "fail" }, "must-pass"), 1);
+  assert.equal(behaviorEvalExecutionExitCode({ status: "expected-failure" }, "known-failure"), 0);
+  assert.equal(behaviorEvalExecutionExitCode({ status: "unexpected-pass" }, "known-failure"), 1);
+  assert.equal(behaviorEvalExecutionExitCode({ status: "fail" }, "report-only"), 0);
+});
+
 test("behavior eval markdown report names the TDD target and command", () => {
   const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
   const markdown = renderBehaviorEvalMarkdown(plan);
@@ -140,7 +171,7 @@ test("behavior eval loader reads the context-engine quarantine release gate", as
 });
 
 test("behavior eval executor requires explicit isolated execution opt-in", async () => {
-  const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+  const plan = buildLocalPlan(historicalProfile, scenario);
 
   await assert.rejects(
     () =>
@@ -152,10 +183,23 @@ test("behavior eval executor requires explicit isolated execution opt-in", async
   );
 });
 
+test("behavior eval executor rejects unimplemented non-local runners", async () => {
+  const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+
+  await assert.rejects(
+    () =>
+      executeBehaviorEvalPlan(plan, {
+        env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+        runCommand: async () => ({ exitCode: 0, stdout: "", stderr: "", wallMs: 1 }),
+      }),
+    /runner\.execution=local/,
+  );
+});
+
 test("behavior eval executor records isolated setup, config, and gateway readiness", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
   try {
-    const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+    const plan = buildLocalPlan(historicalProfile, scenario);
     const commands = [];
     const rpcCalls = [];
     const commandEnvs = [];
@@ -254,7 +298,7 @@ test("behavior eval executor records isolated setup, config, and gateway readine
 test("behavior eval executor classifies historical LCM install failures as expected failures", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
   try {
-    const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+    const plan = buildLocalPlan(historicalProfile, scenario);
     const result = await executeBehaviorEvalPlan(plan, {
       env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
       workspace: {
@@ -290,7 +334,7 @@ test("behavior eval executor classifies historical LCM install failures as expec
 test("behavior eval executor classifies historical LCM gateway-turn failures as expected failures", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
   try {
-    const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+    const plan = buildLocalPlan(historicalProfile, scenario);
     const result = await executeBehaviorEvalPlan(plan, {
       env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
       workspace: {
@@ -335,7 +379,7 @@ test("behavior eval executor fails recall when the token only appears in earlier
       id: "forward-lcm-release-gate",
       expectation: { mode: "must-pass" },
     };
-    const plan = buildBehaviorEvalPlan({ profile, scenario });
+    const plan = buildLocalPlan(profile, scenario);
     let sendCount = 0;
     const result = await executeBehaviorEvalPlan(plan, {
       env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
@@ -404,7 +448,7 @@ test("behavior eval executor passes when a broken context engine is downgraded a
   try {
     const profile = await loadBehaviorEvalProfile("forward-context-engine-quarantine-gate");
     const loadedScenario = await loadBehaviorEvalScenario(profile.scenario);
-    const plan = buildBehaviorEvalPlan({ profile, scenario: loadedScenario });
+    const plan = buildLocalPlan(profile, loadedScenario);
     const commands = [];
     const result = await executeBehaviorEvalPlan(plan, {
       env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
@@ -473,7 +517,7 @@ test("behavior eval executor fails when broken context engine quarantine is not 
   try {
     const profile = await loadBehaviorEvalProfile("forward-context-engine-quarantine-gate");
     const loadedScenario = await loadBehaviorEvalScenario(profile.scenario);
-    const plan = buildBehaviorEvalPlan({ profile, scenario: loadedScenario });
+    const plan = buildLocalPlan(profile, loadedScenario);
     const result = await executeBehaviorEvalPlan(plan, {
       env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
       workspace: {
@@ -521,7 +565,7 @@ test("behavior eval executor fails when broken context engine quarantine is not 
 test("behavior eval executor classifies historical LCM agent-turn failures as expected failures", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
   try {
-    const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+    const plan = buildLocalPlan(historicalProfile, scenario);
     const result = await executeBehaviorEvalPlan(plan, {
       env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
       workspace: {

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import {
   behaviorEvalExecutionExitCode,
   buildBehaviorEvalPlan,
+  buildBehaviorEvalMockResponseText,
   executeBehaviorEvalPlan,
   loadBehaviorEvalProfile,
   loadBehaviorEvalScenario,
@@ -160,6 +161,19 @@ test("behavior eval exit code follows expectation contract", () => {
   assert.equal(behaviorEvalExecutionExitCode({ status: "fail" }, "report-only"), 0);
 });
 
+test("behavior eval mock recall derives answers from request context", () => {
+  assert.equal(
+    buildBehaviorEvalMockResponseText("What is CRABPOT_LCM_FACT?"),
+    "I do not have that fact.",
+  );
+  assert.equal(
+    buildBehaviorEvalMockResponseText(
+      "Memory: CRABPOT_LCM_FACT is blue-lantern-42.\nWhat is CRABPOT_LCM_FACT?",
+    ),
+    "blue-lantern-42",
+  );
+});
+
 test("behavior eval markdown report names the TDD target and command", () => {
   const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
   const markdown = renderBehaviorEvalMarkdown(plan);
@@ -265,8 +279,8 @@ test("behavior eval executor records isolated setup, config, and gateway readine
         baseUrl: "http://127.0.0.1:45678",
         stop: async () => {},
       }),
-      runGatewayRpc: async (method, params) => {
-        rpcCalls.push({ method, params });
+      runGatewayRpc: async (method, params, context, options) => {
+        rpcCalls.push({ method, params, options });
         if (method === "chat.send") {
           return { status: "started", runId: params.idempotencyKey };
         }
@@ -315,6 +329,8 @@ test("behavior eval executor records isolated setup, config, and gateway readine
     assert.equal(rpcCalls[0].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn");
     assert.match(rpcCalls[0].params.message, /CRABPOT_LCM_FACT/);
     assert.equal(rpcCalls[1].params.runId, rpcCalls[0].params.idempotencyKey);
+    assert.equal(rpcCalls[1].params.timeoutMs, 900000);
+    assert.equal(rpcCalls[1].options.timeoutMs, 905000);
 
     const config = JSON.parse(await readFile(path.join(tempRoot, "config.json"), "utf8"));
     assert.deepEqual(config.plugins.slots, { contextEngine: "lossless-claw" });

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -21,8 +21,8 @@ import {
 const scenario = {
   id: "lcm-basic-memory-turn",
   category: "context-engine",
-  description: "Install LCM, select it as the context engine, and run one memory-shaped turn.",
-  recallScope: "cross-session",
+  description: "Install LCM, select it as the context engine, and run two memory-shaped turns.",
+  recallScope: "same-session-key",
   checks: [
     { id: "install", description: "LCM package installs" },
     { id: "gateway-load", description: "Gateway starts with LCM selected" },
@@ -330,8 +330,8 @@ test("behavior eval executor records isolated setup, config, and gateway readine
       "agent.wait",
       "chat.history",
     ]);
-    assert.equal(rpcCalls[0].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:seed");
-    assert.equal(rpcCalls[3].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:recall");
+    assert.equal(rpcCalls[0].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
+    assert.equal(rpcCalls[3].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
     assert.match(rpcCalls[0].params.message, /CRABPOT_LCM_FACT/);
     assert.equal(rpcCalls[1].params.runId, rpcCalls[0].params.idempotencyKey);
     assert.equal(rpcCalls[1].params.timeoutMs, 900000);

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -36,7 +36,12 @@ const historicalProfile = {
   scenario: "lcm-basic-memory-turn",
   expectation: {
     mode: "known-failure",
-    failureClasses: ["embedded-attempt-session-takeover", "agent-runner-unavailable", "memory-recall-mismatch"],
+    failureClasses: [
+      "embedded-attempt-session-takeover",
+      "agent-runner-unavailable",
+      "behavior-turn-mismatch",
+      "memory-recall-mismatch",
+    ],
   },
   openclaw: {
     source: "npm",
@@ -76,6 +81,7 @@ test("behavior eval planner builds the historical LCM repro steps", () => {
   assert.deepEqual(plan.expectedFailureClasses, [
     "embedded-attempt-session-takeover",
     "agent-runner-unavailable",
+    "behavior-turn-mismatch",
     "memory-recall-mismatch",
   ]);
   assert.equal(plan.summary.openclaw, "openclaw@2026.5.22");
@@ -110,6 +116,7 @@ test("behavior eval profile resolver applies ad hoc version overrides", () => {
   assert.equal(resolved.openclaw.version, "2026.5.26");
   assert.equal(resolved.plugins[0].spec, "@martian-engineering/lossless-claw@0.12.0");
   assert.equal(resolved.expectation.mode, "must-pass");
+  assert.equal(resolved.expectation.failureClasses, undefined);
   assert.equal(resolved.runner.execution, "local");
 });
 
@@ -171,9 +178,33 @@ test("behavior eval mock recall derives answers from request context", () => {
   );
   assert.equal(
     buildBehaviorEvalMockResponseText(
-      "Memory: CRABPOT_LCM_FACT is blue-lantern-42.\nWhat is CRABPOT_LCM_FACT?",
+      "Reply with this exact memory marker: CRABPOT_LCM_FACT is blue-lantern-42.",
+    ),
+    "CRABPOT_LCM_FACT is blue-lantern-42.",
+  );
+  assert.equal(
+    buildBehaviorEvalMockResponseText(
+      "Reply with this exact memory marker: CRABPOT_LCM_FACT is blue-lantern-42.\nSay one neutral filler response.",
+    ),
+    "ok",
+  );
+  assert.equal(
+    buildBehaviorEvalMockResponseText(
+      "User: CRABPOT_LCM_FACT is blue-lantern-42.\nWhat is CRABPOT_LCM_FACT?",
+    ),
+    "I do not have that fact.",
+  );
+  assert.equal(
+    buildBehaviorEvalMockResponseText(
+      "<summary id=\"s1\" kind=\"leaf\"><content>CRABPOT_LCM_FACT is blue-lantern-42.</content></summary>\nWhat is CRABPOT_LCM_FACT?",
     ),
     "blue-lantern-42",
+  );
+  assert.equal(
+    buildBehaviorEvalMockResponseText(
+      "You summarize a SEGMENT of an OpenClaw conversation for future model turns.\n<conversation_segment>\nCRABPOT_LCM_FACT is blue-lantern-42.\n</conversation_segment>",
+    ),
+    "CRABPOT_LCM_FACT is blue-lantern-42.",
   );
 });
 
@@ -195,7 +226,8 @@ test("behavior eval loader reads the default forward LCM release gate", async ()
 
   assert.equal(plan.profileId, "forward-lcm-release-gate");
   assert.equal(plan.scenario.id, "lcm-basic-memory-turn");
-  assert.equal(plan.expectation.mode, "must-pass");
+  assert.equal(plan.expectation.mode, "known-failure");
+  assert.deepEqual(plan.expectedFailureClasses, ["memory-recall-mismatch"]);
   assert.equal(plan.summary.openclaw, "openclaw@latest");
   assert.match(plan.summary.plugins, /@martian-engineering\/lossless-claw@latest/);
 });
@@ -339,7 +371,11 @@ test("behavior eval executor records isolated setup, config, and gateway readine
 
     const config = JSON.parse(await readFile(path.join(tempRoot, "config.json"), "utf8"));
     assert.deepEqual(config.plugins.slots, { contextEngine: "lossless-claw" });
-    assert.deepEqual(config.plugins.entries, { "lossless-claw": { enabled: true } });
+    assert.deepEqual(config.plugins.entries, {
+      "lossless-claw": {
+        enabled: true,
+      },
+    });
     assert.equal(config.gateway.port, 19789);
     assert.equal(config.gateway.auth.token, result.gateway.token);
     assert.deepEqual(config.agents.defaults.model, { primary: "mock-openai/gpt-5.5" });
@@ -391,6 +427,46 @@ test("behavior eval executor classifies historical LCM install failures as expec
   }
 });
 
+test("behavior eval executor reports known failure classes as failures under must-pass override", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const profile = resolveBehaviorEvalProfile({
+      profile: historicalProfile,
+      overrides: { expectationMode: "must-pass", runnerExecution: "local" },
+    });
+    const plan = buildBehaviorEvalPlan({ profile, scenario });
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19793,
+      runCommand: async (command) =>
+        command.includes("plugins install")
+          ? {
+              exitCode: 1,
+              stdout: "",
+              stderr: "EmbeddedAttemptSessionTakeoverError: agent runner failed",
+              wallMs: 1,
+            }
+          : { exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 },
+    });
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.failureClass, "embedded-attempt-session-takeover");
+    assert.deepEqual(result.expectedFailureClasses, []);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("behavior eval executor classifies historical LCM gateway-turn failures as expected failures", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
   try {
@@ -431,6 +507,53 @@ test("behavior eval executor classifies historical LCM gateway-turn failures as 
   }
 });
 
+test("behavior eval executor keeps the forward gate from accepting pre-recall turn mismatches", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const profile = await loadBehaviorEvalProfile("forward-lcm-release-gate");
+    const loadedScenario = await loadBehaviorEvalScenario(profile.scenario);
+    const plan = buildLocalPlan(profile, loadedScenario);
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19797,
+      runCommand: async () => ({ exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 }),
+      startGateway: async () => ({ status: "pass", stdout: "ready", stderr: "", wallMs: 1 }),
+      startProvider: async () => ({
+        baseUrl: "http://127.0.0.1:45685",
+        stop: async () => {},
+      }),
+      runGatewayRpc: async (method, params) => {
+        if (method === "chat.send") {
+          return { status: "started", runId: params.idempotencyKey };
+        }
+        if (method === "agent.wait") {
+          return { status: "ok", runId: params.runId };
+        }
+        if (method === "chat.history") {
+          return { messages: [{ role: "assistant", text: "wrong setup response" }] };
+        }
+        throw new Error(`unexpected rpc method ${method}`);
+      },
+    });
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.failureClass, "behavior-turn-mismatch");
+    assert.match(result.steps.at(-2).stderr, /expected turn 1/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("behavior eval executor fails recall when the token only appears in earlier user text", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
   try {
@@ -439,7 +562,8 @@ test("behavior eval executor fails recall when the token only appears in earlier
       id: "forward-lcm-release-gate",
       expectation: { mode: "must-pass" },
     };
-    const plan = buildLocalPlan(profile, scenario);
+    const loadedScenario = await loadBehaviorEvalScenario("lcm-basic-memory-turn");
+    const plan = buildLocalPlan(profile, loadedScenario);
     let sendCount = 0;
     const result = await executeBehaviorEvalPlan(plan, {
       env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
@@ -480,10 +604,12 @@ test("behavior eval executor fails recall when the token only appears in earlier
                 content: [
                   {
                     type: "text",
-                    text:
-                      sendCount === 1
-                        ? "remembered CRABPOT_LCM_FACT"
-                        : "I do not have that fact.",
+                    text: {
+                      1: "blue-lantern-42",
+                      2: "ok",
+                      3: "status: rotated",
+                      4: "I do not have that fact.",
+                    }[sendCount] ?? "I do not have that fact.",
                   },
                 ],
               },

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -121,6 +121,37 @@ test("behavior eval profile resolver absolutizes local OpenClaw paths", () => {
   assert.equal(resolved.openclaw.path, path.resolve("../openclaw"));
 });
 
+test("behavior eval planner rejects shell-shaped npm coordinates", () => {
+  assert.throws(
+    () =>
+      buildBehaviorEvalPlan({
+        profile: {
+          ...historicalProfile,
+          openclaw: { source: "npm", version: "2026.5.22; echo leaked" },
+        },
+        scenario,
+      }),
+    /openclaw\.version/,
+  );
+
+  assert.throws(
+    () =>
+      buildBehaviorEvalPlan({
+        profile: {
+          ...historicalProfile,
+          plugins: [
+            {
+              ...historicalProfile.plugins[0],
+              spec: "@martian-engineering/lossless-claw@0.11.2; echo leaked",
+            },
+          ],
+        },
+        scenario,
+      }),
+    /plugin spec/,
+  );
+});
+
 test("behavior eval exit code follows expectation contract", () => {
   assert.equal(behaviorEvalExecutionExitCode({ status: "pass" }, "must-pass"), 0);
   assert.equal(behaviorEvalExecutionExitCode({ status: "fail" }, "must-pass"), 1);
@@ -204,7 +235,12 @@ test("behavior eval executor records isolated setup, config, and gateway readine
     const rpcCalls = [];
     const commandEnvs = [];
     const result = await executeBehaviorEvalPlan(plan, {
-      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      env: {
+        CRABPOT_EXECUTE_BEHAVIOR: "1",
+        PATH: "/bin:/usr/bin",
+        OPENAI_API_KEY: "must-not-leak",
+        NPM_TOKEN: "must-not-leak",
+      },
       workspace: {
         tempRoot,
         homeDir: path.join(tempRoot, "home"),
@@ -264,6 +300,9 @@ test("behavior eval executor records isolated setup, config, and gateway readine
     assert.equal(commandEnvs[0].NPM_CONFIG_USERCONFIG, path.join(tempRoot, "npmrc"));
     assert.equal(commandEnvs[0].npm_config_userconfig, path.join(tempRoot, "npmrc"));
     assert.equal(commandEnvs[0].npm_config_before, "");
+    assert.equal(commandEnvs[0].PATH, "/bin:/usr/bin");
+    assert.equal(commandEnvs[0].OPENAI_API_KEY, undefined);
+    assert.equal(commandEnvs[0].NPM_TOKEN, undefined);
     assert.equal(await readFile(path.join(tempRoot, "npmrc"), "utf8"), "");
     assert.deepEqual(rpcCalls.map((call) => call.method), [
       "chat.send",

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -1,0 +1,447 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  buildBehaviorEvalPlan,
+  executeBehaviorEvalPlan,
+  loadBehaviorEvalProfile,
+  loadBehaviorEvalScenario,
+  renderBehaviorEvalMarkdown,
+  resolveBehaviorEvalProfile,
+  stopBehaviorEvalChildProcess,
+} from "../scripts/behavior-eval.mjs";
+
+const scenario = {
+  id: "lcm-basic-memory-turn",
+  category: "context-engine",
+  description: "Install LCM, select it as the context engine, and run one memory-shaped turn.",
+  checks: [
+    { id: "install", description: "LCM package installs" },
+    { id: "gateway-load", description: "Gateway starts with LCM selected" },
+    { id: "agent-turn", description: "Agent turn completes" },
+  ],
+};
+
+const historicalProfile = {
+  id: "recent-lcm-2026-5-22",
+  category: "context-engine",
+  scenario: "lcm-basic-memory-turn",
+  expectation: {
+    mode: "known-failure",
+    failureClasses: ["embedded-attempt-session-takeover", "agent-runner-unavailable", "memory-recall-mismatch"],
+  },
+  openclaw: {
+    source: "npm",
+    version: "2026.5.22",
+  },
+  plugins: [
+    {
+      id: "lossless-claw",
+      source: "npm",
+      spec: "@martian-engineering/lossless-claw@0.11.2",
+      slot: "contextEngine",
+    },
+  ],
+  runner: {
+    providerMode: "mock-openai",
+    execution: "blacksmith",
+    timeoutMs: 900000,
+  },
+};
+
+test("behavior eval planner builds the historical LCM repro steps", () => {
+  const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+
+  assert.equal(plan.profileId, "recent-lcm-2026-5-22");
+  assert.equal(plan.scenario.id, "lcm-basic-memory-turn");
+  assert.equal(plan.expectation.mode, "known-failure");
+  assert.deepEqual(plan.expectedFailureClasses, [
+    "embedded-attempt-session-takeover",
+    "agent-runner-unavailable",
+    "memory-recall-mismatch",
+  ]);
+  assert.equal(plan.summary.openclaw, "openclaw@2026.5.22");
+  assert.equal(plan.summary.plugins, "@martian-engineering/lossless-claw@0.11.2");
+  assert.equal(plan.summary.runner, "blacksmith");
+  assert.equal(plan.steps.map((step) => step.id).join(","), "isolate,openclaw,plugin,config,gateway,scenario,report");
+  assert.ok(
+    plan.steps.some((step) =>
+      step.command?.includes("npm exec --yes --package=openclaw@2026.5.22 -- openclaw"),
+    ),
+  );
+  assert.ok(
+    plan.steps.some((step) =>
+      step.command?.includes("openclaw plugins install npm:@martian-engineering/lossless-claw@0.11.2"),
+    ),
+  );
+  assert.deepEqual(plan.configPatch.plugins.slots, { contextEngine: "lossless-claw" });
+  assert.equal(plan.report.status, "planned-known-failure");
+});
+
+test("behavior eval profile resolver applies ad hoc version overrides", () => {
+  const resolved = resolveBehaviorEvalProfile({
+    profile: historicalProfile,
+    overrides: {
+      openclawVersion: "2026.5.26",
+      pluginSpec: "npm:@martian-engineering/lossless-claw@0.12.0",
+      expectationMode: "must-pass",
+      runnerExecution: "local",
+    },
+  });
+
+  assert.equal(resolved.openclaw.version, "2026.5.26");
+  assert.equal(resolved.plugins[0].spec, "@martian-engineering/lossless-claw@0.12.0");
+  assert.equal(resolved.expectation.mode, "must-pass");
+  assert.equal(resolved.runner.execution, "local");
+});
+
+test("behavior eval markdown report names the TDD target and command", () => {
+  const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+  const markdown = renderBehaviorEvalMarkdown(plan);
+
+  assert.match(markdown, /# Crabpot Behavior Eval Plan/);
+  assert.match(markdown, /recent-lcm-2026-5-22/);
+  assert.match(markdown, /known-failure/);
+  assert.match(markdown, /openclaw@2026\.5\.22/);
+  assert.match(markdown, /@martian-engineering\/lossless-claw@0\.11\.2/);
+});
+
+test("behavior eval loader reads the default forward LCM release gate", async () => {
+  const profile = await loadBehaviorEvalProfile("forward-lcm-release-gate");
+  const loadedScenario = await loadBehaviorEvalScenario(profile.scenario);
+  const plan = buildBehaviorEvalPlan({ profile, scenario: loadedScenario });
+
+  assert.equal(plan.profileId, "forward-lcm-release-gate");
+  assert.equal(plan.scenario.id, "lcm-basic-memory-turn");
+  assert.equal(plan.expectation.mode, "must-pass");
+  assert.equal(plan.summary.openclaw, "openclaw@latest");
+  assert.match(plan.summary.plugins, /@martian-engineering\/lossless-claw@latest/);
+});
+
+test("behavior eval executor requires explicit isolated execution opt-in", async () => {
+  const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+
+  await assert.rejects(
+    () =>
+      executeBehaviorEvalPlan(plan, {
+        env: {},
+        runCommand: async () => ({ exitCode: 0, stdout: "", stderr: "", wallMs: 1 }),
+      }),
+    /CRABPOT_EXECUTE_BEHAVIOR=1/,
+  );
+});
+
+test("behavior eval executor records isolated setup, config, and gateway readiness", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+    const commands = [];
+    const rpcCalls = [];
+    const commandEnvs = [];
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19789,
+      runCommand: async (command, context) => {
+        commands.push(command);
+        commandEnvs.push(context.env);
+        return { exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 };
+      },
+      startGateway: async (command) => {
+        commands.push(command);
+        return { status: "pass", stdout: "ready", stderr: "", wallMs: 1 };
+      },
+      startProvider: async () => ({
+        baseUrl: "http://127.0.0.1:45678",
+        stop: async () => {},
+      }),
+      runGatewayRpc: async (method, params) => {
+        rpcCalls.push({ method, params });
+        if (method === "chat.send") {
+          return { status: "started", runId: params.idempotencyKey };
+        }
+        if (method === "agent.wait") {
+          return { status: "ok", runId: params.runId };
+        }
+        if (method === "chat.history") {
+          return {
+            messages: [
+              {
+                role: "assistant",
+                text:
+                  rpcCalls.filter((call) => call.method === "chat.send").length === 1
+                    ? "remembered CRABPOT_LCM_FACT"
+                    : "blue-lantern-42",
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected rpc method ${method}`);
+      },
+    });
+
+    assert.equal(result.status, "unexpected-pass");
+    assert.equal(result.profileId, "recent-lcm-2026-5-22");
+    assert.equal(result.gateway.port, 19789);
+    assert.deepEqual(result.steps.map((step) => step.id), ["isolate", "openclaw", "plugin", "config", "gateway", "scenario", "report"]);
+    assert.ok(commands.some((command) => command.includes("openclaw@2026.5.22 -- openclaw --version")));
+    assert.ok(commands.some((command) => command.includes("plugins install npm:@martian-engineering/lossless-claw@0.11.2")));
+    assert.ok(commands.some((command) => command.includes("gateway run --allow-unconfigured --bind loopback --port 19789 --token")));
+    assert.equal(commandEnvs[0].NPM_CONFIG_USERCONFIG, path.join(tempRoot, "npmrc"));
+    assert.equal(commandEnvs[0].npm_config_userconfig, path.join(tempRoot, "npmrc"));
+    assert.equal(commandEnvs[0].npm_config_before, "");
+    assert.equal(await readFile(path.join(tempRoot, "npmrc"), "utf8"), "");
+    assert.deepEqual(rpcCalls.map((call) => call.method), [
+      "chat.send",
+      "agent.wait",
+      "chat.history",
+      "chat.send",
+      "agent.wait",
+      "chat.history",
+    ]);
+    assert.equal(rpcCalls[0].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn");
+    assert.match(rpcCalls[0].params.message, /CRABPOT_LCM_FACT/);
+    assert.equal(rpcCalls[1].params.runId, rpcCalls[0].params.idempotencyKey);
+
+    const config = JSON.parse(await readFile(path.join(tempRoot, "config.json"), "utf8"));
+    assert.deepEqual(config.plugins.slots, { contextEngine: "lossless-claw" });
+    assert.deepEqual(config.plugins.entries, { "lossless-claw": { enabled: true } });
+    assert.equal(config.gateway.port, 19789);
+    assert.equal(config.gateway.auth.token, result.gateway.token);
+    assert.deepEqual(config.agents.defaults.model, { primary: "mock-openai/gpt-5.5" });
+    assert.equal(config.agents.list[0].id, "qa");
+    assert.equal(config.models.providers["mock-openai"].baseUrl, "http://127.0.0.1:45678/v1");
+
+    const authProfiles = JSON.parse(
+      await readFile(path.join(tempRoot, "state", "agents", "qa", "agent", "auth-profiles.json"), "utf8"),
+    );
+    assert.equal(authProfiles.profiles["qa-mock-openai"].key, "qa-mock-not-a-real-key");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("behavior eval executor classifies historical LCM install failures as expected failures", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19790,
+      runCommand: async (command) =>
+        command.includes("plugins install")
+          ? {
+              exitCode: 1,
+              stdout: "",
+              stderr: "EmbeddedAttemptSessionTakeoverError: agent runner failed",
+              wallMs: 1,
+            }
+          : { exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 },
+    });
+
+    assert.equal(result.status, "expected-failure");
+    assert.equal(result.failureClass, "embedded-attempt-session-takeover");
+    assert.equal(result.steps.at(-1).id, "plugin");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("behavior eval executor classifies historical LCM gateway-turn failures as expected failures", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19792,
+      runCommand: async () => ({ exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 }),
+      startGateway: async () => ({ status: "pass", stdout: "ready", stderr: "", wallMs: 1 }),
+      startProvider: async () => ({
+        baseUrl: "http://127.0.0.1:45680",
+        stop: async () => {},
+      }),
+      runGatewayRpc: async (method) => {
+        if (method === "chat.send") {
+          return { status: "started", runId: "run-lcm-red" };
+        }
+        throw new Error("EmbeddedAttemptSessionTakeoverError: agent runner failed");
+      },
+    });
+
+    assert.equal(result.status, "expected-failure");
+    assert.equal(result.failureClass, "embedded-attempt-session-takeover");
+    assert.equal(result.steps.at(-2).id, "scenario");
+    assert.equal(result.steps.at(-2).status, "fail");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("behavior eval executor fails recall when the token only appears in earlier user text", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const profile = {
+      ...historicalProfile,
+      id: "forward-lcm-release-gate",
+      expectation: { mode: "must-pass" },
+    };
+    const plan = buildBehaviorEvalPlan({ profile, scenario });
+    let sendCount = 0;
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19793,
+      runCommand: async () => ({ exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 }),
+      startGateway: async () => ({ status: "pass", stdout: "ready", stderr: "", wallMs: 1 }),
+      startProvider: async () => ({
+        baseUrl: "http://127.0.0.1:45681",
+        stop: async () => {},
+      }),
+      runGatewayRpc: async (method, params) => {
+        if (method === "chat.send") {
+          sendCount += 1;
+          return { status: "started", runId: params.idempotencyKey };
+        }
+        if (method === "agent.wait") {
+          return { status: "ok", runId: params.runId };
+        }
+        if (method === "chat.history") {
+          return {
+            messages: [
+              {
+                role: "user",
+                content: [{ type: "text", text: "CRABPOT_LCM_FACT is blue-lantern-42." }],
+              },
+              {
+                role: "assistant",
+                content: [
+                  {
+                    type: "text",
+                    text:
+                      sendCount === 1
+                        ? "remembered CRABPOT_LCM_FACT"
+                        : "I do not have that fact.",
+                  },
+                ],
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected rpc method ${method}`);
+      },
+    });
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.failureClass, "memory-recall-mismatch");
+    assert.equal(result.workspace.kept, false);
+    assert.match(result.steps.at(-2).stderr, /latest assistant/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("behavior eval executor classifies historical LCM agent-turn failures as expected failures", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-behavior-test-"));
+  try {
+    const plan = buildBehaviorEvalPlan({ profile: historicalProfile, scenario });
+    const result = await executeBehaviorEvalPlan(plan, {
+      env: { CRABPOT_EXECUTE_BEHAVIOR: "1" },
+      workspace: {
+        tempRoot,
+        homeDir: path.join(tempRoot, "home"),
+        workspaceDir: path.join(tempRoot, "workspace"),
+        stateDir: path.join(tempRoot, "state"),
+        configPath: path.join(tempRoot, "config.json"),
+        xdgCacheHome: path.join(tempRoot, "xdg-cache"),
+        xdgConfigHome: path.join(tempRoot, "xdg-config"),
+        xdgDataHome: path.join(tempRoot, "xdg-data"),
+      },
+      getFreePort: async () => 19791,
+      runCommand: async () => ({ exitCode: 0, stdout: "ok", stderr: "", wallMs: 1 }),
+      startGateway: async () => ({ status: "pass", stdout: "ready", stderr: "", wallMs: 1 }),
+      startProvider: async () => ({
+        baseUrl: "http://127.0.0.1:45679",
+        stop: async () => {},
+      }),
+      runScenario: async () => ({
+        status: "fail",
+        exitCode: 1,
+        stdout: "",
+        stderr: "EmbeddedAttemptSessionTakeoverError: agent runner failed",
+        wallMs: 1,
+      }),
+    });
+
+    assert.equal(result.status, "expected-failure");
+    assert.equal(result.failureClass, "embedded-attempt-session-takeover");
+    assert.equal(result.steps.at(-2).id, "scenario");
+    assert.equal(result.steps.at(-2).status, "fail");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("behavior eval gateway stop waits for the child process to exit", async () => {
+  const child = new EventEmitter();
+  child.pid = 1234;
+  child.exitCode = null;
+  child.signalCode = null;
+  const signals = [];
+
+  const stopPromise = stopBehaviorEvalChildProcess(child, {
+    timeoutMs: 1000,
+    killProcess: (pid, signal) => {
+      signals.push({ pid, signal });
+      setTimeout(() => {
+        child.exitCode = 0;
+        child.emit("exit", 0, signal);
+      }, 10);
+    },
+  });
+
+  assert.deepEqual(signals, [{ pid: -1234, signal: "SIGTERM" }]);
+  assert.equal(child.exitCode, null);
+  await stopPromise;
+  assert.equal(child.exitCode, 0);
+});

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -21,7 +21,7 @@ import {
 const scenario = {
   id: "lcm-basic-memory-turn",
   category: "context-engine",
-  description: "Install LCM, select it as the context engine, and run two memory-shaped turns.",
+  description: "Install LCM, select it as the context engine, and recall after a session reset.",
   recallScope: "same-session-key",
   checks: [
     { id: "install", description: "LCM package installs" },
@@ -304,6 +304,9 @@ test("behavior eval executor records isolated setup, config, and gateway readine
             ],
           };
         }
+        if (method === "sessions.reset") {
+          return { ok: true, key: params.key };
+        }
         throw new Error(`unexpected rpc method ${method}`);
       },
     });
@@ -326,12 +329,15 @@ test("behavior eval executor records isolated setup, config, and gateway readine
       "chat.send",
       "agent.wait",
       "chat.history",
+      "sessions.reset",
       "chat.send",
       "agent.wait",
       "chat.history",
     ]);
     assert.equal(rpcCalls[0].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
-    assert.equal(rpcCalls[3].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
+    assert.equal(rpcCalls[3].params.key, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
+    assert.equal(rpcCalls[3].params.reason, "reset");
+    assert.equal(rpcCalls[4].params.sessionKey, "agent:qa:discord:channel:crabpot-lcm-basic-memory-turn:default");
     assert.match(rpcCalls[0].params.message, /CRABPOT_LCM_FACT/);
     assert.equal(rpcCalls[1].params.runId, rpcCalls[0].params.idempotencyKey);
     assert.equal(rpcCalls[1].params.timeoutMs, 900000);
@@ -489,6 +495,9 @@ test("behavior eval executor fails recall when the token only appears in earlier
               },
             ],
           };
+        }
+        if (method === "sessions.reset") {
+          return { ok: true, key: params.key };
         }
         throw new Error(`unexpected rpc method ${method}`);
       },

--- a/test/run-static-suite.test.mjs
+++ b/test/run-static-suite.test.mjs
@@ -19,9 +19,17 @@ test("static suite keeps the dashboard gate broad and target-explicit", () => {
     rendered.some(([command, args]) => command === "node" && args === "scripts/run-plugin-inspector-smoke.mjs --check"),
   );
   assert.ok(rendered.some(([, args]) => args === "scripts/run-contract-smoke.mjs --strict --openclaw ./openclaw"));
+  assert.equal(rendered.some(([, args]) => args.startsWith("scripts/behavior-eval.mjs")), false);
   assert.ok(rendered.some(([, args]) => args === "scripts/import-loop-profile.mjs --check --runs 2"));
   assert.ok(rendered.some(([, args]) => args === "scripts/profile-contract-runtime.mjs --check --openclaw ./openclaw --runs 2"));
   assert.ok(rendered.some(([, args]) => args === "scripts/check-ci-policy.mjs --check"));
+});
+
+test("static suite checks behavior eval reports only for default committed targets", () => {
+  const steps = buildStaticSuiteSteps();
+  const rendered = steps.map(([, args]) => args.join(" "));
+
+  assert.ok(rendered.includes("scripts/behavior-eval.mjs --check"));
 });
 
 test("static suite release policy keeps compatibility findings advisory", () => {


### PR DESCRIPTION
## Summary

- Add strict LCM behavior eval coverage for the active `contextEngine` slot, including summary-backed recall after `/lossless rotate`.
- Add a context-engine quarantine behavior profile so Crabpot tracks the OpenClaw downgrade/health contract instead of only plugin API shape.
- Harden `scripts/behavior-eval.mjs` around isolated execution, plugin install records, mock provider context, timeout cleanup, gateway readiness, expectation overrides, and failure classification.

## Verification

- `node --test test/behavior-eval.test.mjs` -> 27 passing tests
- `node scripts/behavior-eval.mjs --check`
- `git diff --check`
- Autoreview: `autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- Crabbox fresh-PR proof: provider `aws`, lease `cbx_190289060e66`, run `run_089e04f98287`, exact PR head `e6695b2de528`, Node `24.15.0`, npm `11.12.1`, exit 0

## Real behavior proof

Behavior addressed: Crabpot now catches LCM/context-engine memory failures after rotate and distinguishes final recall failures from earlier setup/turn failures.

Real environment tested: direct AWS Crabbox on Linux using fresh checkout of `openclaw/crabpot#126`, isolated OpenClaw state, npm-installed `openclaw@latest`, and npm-installed `@martian-engineering/lossless-claw@latest` / `@martian-engineering/lossless-claw@0.11.2` through the behavior runner.

Exact steps or command run after this patch: `node --test test/behavior-eval.test.mjs test/run-static-suite.test.mjs && node scripts/behavior-eval.mjs --check && CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --execute --profile forward-lcm-release-gate --runner local --timeout-ms 240000 && CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --execute --profile recent-lcm-2026-5-22 --runner local --timeout-ms 240000`.

Evidence after fix: `run_089e04f98287` reached exact head `e6695b2de528`; the forward/latest LCM gate reached the final recall turn and recorded expected failure class `memory-recall-mismatch`; the historical `2026.5.22` profile recorded expected failure class `behavior-turn-mismatch` before final recall.

Observed result after fix: latest OpenClaw plus latest LCM still does not recall `CRABPOT_LCM_FACT` from summarized context after rotate; Crabpot now catches that as expected-red rather than passing via raw transcript replay. The historical profile is separately classified so older setup/turn failures do not dilute the forward release signal.

What was not tested: a must-pass released OpenClaw+LCM combination, because latest LCM is still red; a candidate OpenClaw PR probe against https://github.com/openclaw/openclaw/pull/87640 also failed strict summary-backed recall with `memory-recall-mismatch`, so that semantic recall fix remains follow-up work outside this Crabpot PR.
