### PR TITLE
test: support npm-pack behavior eval plugins

### DIFF
--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -240,8 +240,7 @@ export function resolveBehaviorEvalProfile({ profile, overrides = {} }) {
     }
     next.plugins[0] = {
       ...next.plugins[0],
-      source: "npm",
-      spec: normalizeNpmPluginSpec(overrides.pluginSpec),
+      ...resolvePluginOverrideSpec(overrides.pluginSpec),
     };
   }
   if (overrides.expectationMode) {
@@ -2033,14 +2032,29 @@ function formatPluginInstallSpec(plugin) {
   if (plugin.source === "npm") {
     return shellQuote(`npm:${plugin.spec}`);
   }
+  if (plugin.source === "npm-pack") {
+    return shellQuote(`npm-pack:${plugin.path}`);
+  }
   if (plugin.source === "fixture") {
     return fixtureInstallToken(plugin.fixture);
   }
   throw new Error(`unsupported plugin source for ${plugin.id}: ${plugin.source}`);
 }
 
+function resolvePluginOverrideSpec(spec) {
+  const npmPackPath = normalizeNpmPackPluginSpec(spec);
+  if (npmPackPath !== null) {
+    return { source: "npm-pack", path: npmPackPath };
+  }
+  return { source: "npm", spec: normalizeNpmPluginSpec(spec) };
+}
+
 function normalizeNpmPluginSpec(spec) {
   return spec.startsWith("npm:") ? spec.slice("npm:".length) : spec;
+}
+
+function normalizeNpmPackPluginSpec(spec) {
+  return spec.startsWith("npm-pack:") ? spec.slice("npm-pack:".length) : null;
 }
 
 function isSafeNpmCoordinate(value) {
@@ -2054,6 +2068,9 @@ function fixtureInstallToken(fixture) {
 function formatPluginSummary(plugin) {
   if (plugin.source === "npm") {
     return plugin.spec;
+  }
+  if (plugin.source === "npm-pack") {
+    return `npm-pack:${plugin.path}`;
   }
   if (plugin.source === "fixture") {
     return `fixture:${plugin.fixture}`;
@@ -2115,13 +2132,18 @@ function validateBehaviorEvalProfile(profile, label) {
       if (!/^[a-z0-9][a-z0-9-]*$/.test(plugin.id ?? "")) {
         errors.push("plugin id must be kebab-case");
       }
-      if (!["npm", "fixture"].includes(plugin.source)) {
-        errors.push(`${plugin.id}: plugin source must be npm or fixture`);
+      if (!["npm", "npm-pack", "fixture"].includes(plugin.source)) {
+        errors.push(`${plugin.id}: plugin source must be npm, npm-pack, or fixture`);
       }
       if (plugin.source === "npm" && (typeof plugin.spec !== "string" || plugin.spec.trim().length === 0)) {
         errors.push(`${plugin.id}: plugin spec must be set`);
       } else if (plugin.source === "npm" && !isSafeNpmCoordinate(plugin.spec)) {
         errors.push(`${plugin.id}: plugin spec must be an npm package spec without shell metacharacters`);
+      }
+      if (plugin.source === "npm-pack" && (typeof plugin.path !== "string" || plugin.path.trim().length === 0)) {
+        errors.push(`${plugin.id}: plugin npm-pack path must be set`);
+      } else if (plugin.source === "npm-pack" && !isSafeNpmCoordinate(plugin.path)) {
+        errors.push(`${plugin.id}: plugin npm-pack path must not contain shell metacharacters`);
       }
       if (plugin.source === "fixture" && !/^[a-z0-9][a-z0-9-]*$/.test(plugin.fixture ?? "")) {
         errors.push(`${plugin.id}: plugin fixture must be kebab-case`);

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -2042,7 +2042,7 @@ function formatPluginInstallSpec(plugin) {
 }
 
 function resolvePluginOverrideSpec(spec) {
-  const npmPackPath = normalizeNpmPackPluginSpec(spec);
+  const npmPackPath = resolveNpmPackPluginPath(spec);
   if (npmPackPath !== null) {
     return { source: "npm-pack", path: npmPackPath };
   }
@@ -2053,12 +2053,20 @@ function normalizeNpmPluginSpec(spec) {
   return spec.startsWith("npm:") ? spec.slice("npm:".length) : spec;
 }
 
-function normalizeNpmPackPluginSpec(spec) {
-  return spec.startsWith("npm-pack:") ? spec.slice("npm-pack:".length) : null;
+function resolveNpmPackPluginPath(spec) {
+  if (!spec.startsWith("npm-pack:")) {
+    return null;
+  }
+  const rawPath = spec.slice("npm-pack:".length);
+  return rawPath.trim().length === 0 ? rawPath : path.resolve(rawPath);
 }
 
 function isSafeNpmCoordinate(value) {
   return /^[A-Za-z0-9_./:@+-]+$/.test(value);
+}
+
+function isSafeNpmPackPath(value) {
+  return /^[A-Za-z0-9_./:\\@+-]+$/.test(value);
 }
 
 function fixtureInstallToken(fixture) {
@@ -2142,7 +2150,7 @@ function validateBehaviorEvalProfile(profile, label) {
       }
       if (plugin.source === "npm-pack" && (typeof plugin.path !== "string" || plugin.path.trim().length === 0)) {
         errors.push(`${plugin.id}: plugin npm-pack path must be set`);
-      } else if (plugin.source === "npm-pack" && !isSafeNpmCoordinate(plugin.path)) {
+      } else if (plugin.source === "npm-pack" && !isSafeNpmPackPath(plugin.path)) {
         errors.push(`${plugin.id}: plugin npm-pack path must not contain shell metacharacters`);
       }
       if (plugin.source === "fixture" && !/^[a-z0-9][a-z0-9-]*$/.test(plugin.fixture ?? "")) {
@@ -2215,7 +2223,10 @@ function indentBlock(value, indent) {
 }
 
 function shellQuote(value) {
-  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) {
+  const safePattern = process.platform === "win32"
+    ? /^[A-Za-z0-9_./:\\=@+-]+$/
+    : /^[A-Za-z0-9_./:=@+-]+$/;
+  if (safePattern.test(value)) {
     return value;
   }
   return `'${value.replaceAll("'", "'\\''")}'`;

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -120,6 +120,29 @@ test("behavior eval profile resolver applies ad hoc version overrides", () => {
   assert.equal(resolved.runner.execution, "local");
 });
 
+test("behavior eval profile resolver preserves npm-pack plugin overrides", () => {
+  const resolved = resolveBehaviorEvalProfile({
+    profile: historicalProfile,
+    overrides: {
+      pluginSpec: "npm-pack:/tmp/martian-engineering-lossless-claw-0.11.3.tgz",
+      expectationMode: "must-pass",
+      runnerExecution: "local",
+    },
+  });
+  const plan = buildBehaviorEvalPlan({ profile: resolved, scenario });
+
+  assert.equal(resolved.plugins[0].source, "npm-pack");
+  assert.equal(resolved.plugins[0].path, "/tmp/martian-engineering-lossless-claw-0.11.3.tgz");
+  assert.equal(plan.summary.plugins, "npm-pack:/tmp/martian-engineering-lossless-claw-0.11.3.tgz");
+  assert.ok(
+    plan.steps.some((step) =>
+      step.command?.includes(
+        "openclaw plugins install npm-pack:/tmp/martian-engineering-lossless-claw-0.11.3.tgz",
+      ),
+    ),
+  );
+});
+
 test("behavior eval profile resolver absolutizes local OpenClaw paths", () => {
   const resolved = resolveBehaviorEvalProfile({
     profile: historicalProfile,

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -62,6 +62,43 @@ const historicalProfile = {
   },
 };
 
+const genericScenario = {
+  id: "generic-context-engine-turn",
+  category: "context-engine",
+  description: "Install a generic context engine plugin and run a behavior-shaped turn.",
+  recallScope: "same-session-key",
+  checks: [
+    { id: "install", description: "Generic package installs" },
+    { id: "gateway-load", description: "Gateway starts with the generic plugin selected" },
+  ],
+};
+
+const genericProfile = {
+  id: "generic-context-engine-release-gate",
+  category: "context-engine",
+  scenario: "generic-context-engine-turn",
+  expectation: {
+    mode: "must-pass",
+  },
+  openclaw: {
+    source: "npm",
+    version: "2026.5.22",
+  },
+  plugins: [
+    {
+      id: "sample-context-engine",
+      source: "npm",
+      spec: "@example/sample-context-engine@1.0.0",
+      slot: "contextEngine",
+    },
+  ],
+  runner: {
+    providerMode: "mock-openai",
+    execution: "local",
+    timeoutMs: 900000,
+  },
+};
+
 function buildLocalPlan(profile, scenarioValue) {
   return buildBehaviorEvalPlan({
     profile: resolveBehaviorEvalProfile({
@@ -120,27 +157,48 @@ test("behavior eval profile resolver applies ad hoc version overrides", () => {
   assert.equal(resolved.runner.execution, "local");
 });
 
-test("behavior eval profile resolver preserves npm-pack plugin overrides", () => {
+test("behavior eval profile resolver absolutizes generic npm-pack plugin overrides", () => {
+  const relativeTarball = "fixtures/sample-context-engine-0.0.0.tgz";
+  const resolvedTarball = path.resolve(relativeTarball);
   const resolved = resolveBehaviorEvalProfile({
-    profile: historicalProfile,
+    profile: genericProfile,
     overrides: {
-      pluginSpec: "npm-pack:/tmp/martian-engineering-lossless-claw-0.11.3.tgz",
+      pluginSpec: `npm-pack:${relativeTarball}`,
       expectationMode: "must-pass",
       runnerExecution: "local",
     },
   });
-  const plan = buildBehaviorEvalPlan({ profile: resolved, scenario });
+  const plan = buildBehaviorEvalPlan({ profile: resolved, scenario: genericScenario });
+  const planText = [plan.summary.plugins, ...plan.steps.map((step) => step.command ?? "")].join("\n");
 
   assert.equal(resolved.plugins[0].source, "npm-pack");
-  assert.equal(resolved.plugins[0].path, "/tmp/martian-engineering-lossless-claw-0.11.3.tgz");
-  assert.equal(plan.summary.plugins, "npm-pack:/tmp/martian-engineering-lossless-claw-0.11.3.tgz");
+  assert.equal(resolved.plugins[0].path, resolvedTarball);
+  assert.equal(plan.summary.plugins, `npm-pack:${resolvedTarball}`);
   assert.ok(
     plan.steps.some((step) =>
-      step.command?.includes(
-        "openclaw plugins install npm-pack:/tmp/martian-engineering-lossless-claw-0.11.3.tgz",
-      ),
+      step.command?.includes(`openclaw plugins install npm-pack:${resolvedTarball}`),
     ),
   );
+  assert.doesNotMatch(planText, /lossless/i);
+});
+
+test("behavior eval planner accepts Windows npm-pack paths", () => {
+  const windowsTarball = String.raw`D:\a\crabpot\fixtures\sample-context-engine-0.0.0.tgz`;
+  const plan = buildBehaviorEvalPlan({
+    profile: {
+      ...genericProfile,
+      plugins: [
+        {
+          ...genericProfile.plugins[0],
+          source: "npm-pack",
+          path: windowsTarball,
+        },
+      ],
+    },
+    scenario: genericScenario,
+  });
+
+  assert.equal(plan.summary.plugins, `npm-pack:${windowsTarball}`);
 });
 
 test("behavior eval profile resolver absolutizes local OpenClaw paths", () => {
@@ -183,6 +241,28 @@ test("behavior eval planner rejects shell-shaped npm coordinates", () => {
         scenario,
       }),
     /plugin spec/,
+  );
+
+  assert.throws(
+    () =>
+      resolveBehaviorEvalProfile({
+        profile: genericProfile,
+        overrides: {
+          pluginSpec: "npm-pack:fixtures/sample-context-engine-0.0.0.tgz; echo leaked",
+        },
+      }),
+    /npm-pack path/,
+  );
+
+  assert.throws(
+    () =>
+      resolveBehaviorEvalProfile({
+        profile: genericProfile,
+        overrides: {
+          pluginSpec: "npm-pack:",
+        },
+      }),
+    /npm-pack path/,
   );
 });
 


### PR DESCRIPTION
## What
Adds generic `npm-pack:` plugin override support to the behavior eval planner and executor so local plugin tarballs can be installed in isolated eval runs.

## Why
This lets Crabpot validate unpublished plugin branches before package release without coupling the harness to any specific plugin repository.

## Changes
- Parse `npm-pack:` plugin overrides
- Resolve pack paths before execution
- Reject empty/unsafe pack paths
- Cover generic pack planning

## Testing
- `node --test test/behavior-eval.test.mjs`
  - Expected: 24 passing behavior-eval tests.
- `npm run eval:behavior -- --check`
  - Expected: generated behavior reports remain current.
- Generic local proof with a disposable `@crabpot/sample-npm-pack-plugin` tarball:
  - Command shape: `CRABPOT_EXECUTE_BEHAVIOR=1 node scripts/behavior-eval.mjs --profile sample-npm-pack-proof --profile-dir <tmp>/profiles --scenario-dir <tmp>/scenarios --plugin npm-pack:<relative path to generic tarball> --runner local --expect must-pass --execute --timeout-ms 120000 --results-dir <tmp>/results --json`
  - Expected: execution `status: pass`; plugin step installs `sample-npm-pack-plugin`; gateway starts; scenario returns assistant text `ok`.
