### PR TITLE
test: exercise LCM rotate summary-backed recall

### DIFF
--- a/evals/profiles/forward-lcm-release-gate.json
+++ b/evals/profiles/forward-lcm-release-gate.json
@@ -18,7 +18,7 @@
       "spec": "@martian-engineering/lossless-claw@latest",
       "slot": "contextEngine",
       "config": {
-        "freshTailCount": 1,
+        "freshTailCount": 8,
         "leafMinFanout": 2,
         "leafChunkTokens": 100,
         "summaryPrefixTargetTokens": 100

--- a/evals/scenarios/lcm-basic-memory-turn.json
+++ b/evals/scenarios/lcm-basic-memory-turn.json
@@ -1,7 +1,7 @@
 {
   "id": "lcm-basic-memory-turn",
   "category": "context-engine",
-  "description": "Install LCM, select it as the context engine, rotate the transcript, and recall an assistant-seeded fact through one stable session key.",
+  "description": "Install LCM, select it as the context engine, build raw context beyond the fresh tail, rotate the transcript, and recall a fact through summarized context.",
   "recallScope": "same-session-key",
   "checks": [
     {
@@ -18,7 +18,7 @@
     },
     {
       "id": "memory-assembly",
-      "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the assistant-seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure."
+      "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure."
     }
   ],
   "turns": [
@@ -30,6 +30,16 @@
     {
       "sessionSuffix": "default",
       "message": "Say one neutral filler response.",
+      "expectText": "ok"
+    },
+    {
+      "sessionSuffix": "default",
+      "message": "Say a second neutral filler response.",
+      "expectText": "ok"
+    },
+    {
+      "sessionSuffix": "default",
+      "message": "Say a third neutral filler response.",
       "expectText": "ok"
     },
     {

--- a/reports/crabpot-behavior-evals.json
+++ b/reports/crabpot-behavior-evals.json
@@ -30,7 +30,7 @@
       "scenario": {
         "id": "lcm-basic-memory-turn",
         "category": "context-engine",
-        "description": "Install LCM, select it as the context engine, rotate the transcript, and recall an assistant-seeded fact through one stable session key.",
+        "description": "Install LCM, select it as the context engine, build raw context beyond the fresh tail, rotate the transcript, and recall a fact through summarized context.",
         "recallScope": "same-session-key",
         "checks": [
           {
@@ -47,7 +47,7 @@
           },
           {
             "id": "memory-assembly",
-            "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the assistant-seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure."
+            "description": "A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure."
           }
         ],
         "turns": [
@@ -59,6 +59,16 @@
           {
             "sessionSuffix": "default",
             "message": "Say one neutral filler response.",
+            "expectText": "ok"
+          },
+          {
+            "sessionSuffix": "default",
+            "message": "Say a second neutral filler response.",
+            "expectText": "ok"
+          },
+          {
+            "sessionSuffix": "default",
+            "message": "Say a third neutral filler response.",
             "expectText": "ok"
           },
           {
@@ -86,7 +96,7 @@
           "spec": "@martian-engineering/lossless-claw@latest",
           "slot": "contextEngine",
           "config": {
-            "freshTailCount": 1,
+            "freshTailCount": 8,
             "leafMinFanout": 2,
             "leafChunkTokens": 100,
             "summaryPrefixTargetTokens": 100
@@ -112,7 +122,7 @@
             "lossless-claw": {
               "enabled": true,
               "config": {
-                "freshTailCount": 1,
+                "freshTailCount": 8,
                 "leafMinFanout": 2,
                 "leafChunkTokens": 100,
                 "summaryPrefixTargetTokens": 100
@@ -152,7 +162,7 @@
                 "lossless-claw": {
                   "enabled": true,
                   "config": {
-                    "freshTailCount": 1,
+                    "freshTailCount": 8,
                     "leafMinFanout": 2,
                     "leafChunkTokens": 100,
                     "summaryPrefixTargetTokens": 100
@@ -171,7 +181,7 @@
         {
           "id": "scenario",
           "title": "Run scenario",
-          "description": "Install LCM, select it as the context engine, rotate the transcript, and recall an assistant-seeded fact through one stable session key.",
+          "description": "Install LCM, select it as the context engine, build raw context beyond the fresh tail, rotate the transcript, and recall a fact through summarized context.",
           "checks": [
             "install",
             "gateway-load",

--- a/reports/crabpot-behavior-evals.md
+++ b/reports/crabpot-behavior-evals.md
@@ -37,7 +37,7 @@
    ```
 
 6. Run scenario
-   Install LCM, select it as the context engine, rotate the transcript, and recall an assistant-seeded fact through one stable session key.
+   Install LCM, select it as the context engine, build raw context beyond the fresh tail, rotate the transcript, and recall a fact through summarized context.
 7. Classify result
    Expected mode is known-failure.
 ## Scenario Checks
@@ -45,7 +45,7 @@
 - install: The requested OpenClaw package resolves and the LCM npm plugin installs into isolated state.
 - gateway-load: The gateway starts with lossless-claw enabled and selected in the contextEngine slot.
 - agent-turn: An agent call emits a seeded memory fact and returns a completed run or a classified failure.
-- memory-assembly: A follow-up turn on the same stable session key after /lossless rotate can observe the assistant-seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure.
+- memory-assembly: A follow-up turn on the same stable session key after /lossless rotate can observe the seeded fact through summarized LCM context, or the run is classified as an LCM assembly failure.
 
 ## Planned Classification
 

--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1326,13 +1326,13 @@ export function buildBehaviorEvalMockResponseText(inputText) {
     const fact = extractBehaviorEvalFactValue(inputText);
     return fact ? `CRABPOT_LCM_FACT is ${fact}.` : "No CRABPOT_LCM_FACT was present.";
   }
+  if (/what is crabpot_lcm_fact|recall.*crabpot_lcm_fact/iu.test(inputText)) {
+    return extractBehaviorEvalContextFactValue(inputText) ?? "I do not have that fact.";
+  }
   if (/Say one neutral filler response/iu.test(inputText)) {
     return "ok";
   }
   if (/remember.*crabpot_lcm_fact|crabpot_lcm_fact/iu.test(inputText)) {
-    if (/what is crabpot_lcm_fact|recall.*crabpot_lcm_fact/iu.test(inputText)) {
-      return extractBehaviorEvalContextFactValue(inputText) ?? "I do not have that fact.";
-    }
     if (/reply.*crabpot_lcm_fact|exact memory marker/iu.test(inputText)) {
       const fact = extractBehaviorEvalFactValue(inputText);
       return fact ? `CRABPOT_LCM_FACT is ${fact}.` : "CRABPOT_LCM_FACT is missing.";

--- a/test/behavior-eval.test.mjs
+++ b/test/behavior-eval.test.mjs
@@ -225,6 +225,12 @@ test("behavior eval mock recall derives answers from request context", () => {
   );
   assert.equal(
     buildBehaviorEvalMockResponseText(
+      "<summary id=\"s1\" kind=\"leaf\"><content>CRABPOT_LCM_FACT is blue-lantern-42. Say one neutral filler response.</content></summary>\nWhat is CRABPOT_LCM_FACT?",
+    ),
+    "blue-lantern-42",
+  );
+  assert.equal(
+    buildBehaviorEvalMockResponseText(
       "You summarize a SEGMENT of an OpenClaw conversation for future model turns.\n<conversation_segment>\nCRABPOT_LCM_FACT is blue-lantern-42.\n</conversation_segment>",
     ),
     "CRABPOT_LCM_FACT is blue-lantern-42.",
@@ -630,8 +636,10 @@ test("behavior eval executor fails recall when the token only appears in earlier
                     text: {
                       1: "blue-lantern-42",
                       2: "ok",
-                      3: "status: rotated",
-                      4: "I do not have that fact.",
+                      3: "ok",
+                      4: "ok",
+                      5: "status: rotated",
+                      6: "I do not have that fact.",
                     }[sendCount] ?? "I do not have that fact.",
                   },
                 ],


### PR DESCRIPTION
## What
Updates the forward LCM behavior eval to exercise `/lossless rotate` with realistic fresh-tail settings and verify recall from summary-backed assembled context.

## Why
PR #126's original shape used an unrealistic one-message fresh tail. This version keeps the fact outside a realistic fresh tail, requires rotate to preserve it through summary coverage, and validates the current Lossless branch via npm-pack.

## Changes
- Add pre-rotate filler turns
- Use realistic fresh tail
- Prioritize recall mock responses
- Refresh behavior eval reports

## Testing
- `node --test test/behavior-eval.test.mjs`
- `npm run eval:behavior -- --check`
- `CRABPOT_EXECUTE_BEHAVIOR=1 npm run eval:behavior -- --plugin npm-pack:/tmp/martian-engineering-lossless-claw-0.11.3.tgz --runner local --expect must-pass --execute --keep-temp --timeout-ms 900000`
