### PR TITLE
fix(eval): avoid exposing mock provider errors

### DIFF
--- a/scripts/behavior-eval.mjs
+++ b/scripts/behavior-eval.mjs
@@ -1237,8 +1237,8 @@ function startBehaviorEvalMockOpenAiProvider() {
         return;
       }
       writeBehaviorEvalJson(res, 404, { error: "not found" });
-    } catch (error) {
-      writeBehaviorEvalJson(res, 500, { error: formatErrorForReport(error) });
+    } catch {
+      writeBehaviorEvalJson(res, 500, { error: "mock provider request failed" });
     }
   });
 


### PR DESCRIPTION
## Summary
- Stop returning internal mock-provider exception details over HTTP 500 responses.
- Preserve detailed error reporting for local behavior-eval command/report paths.

## Verification
- `node --test --test-concurrency=1 test/behavior-eval.test.mjs`
- `git diff --check`
