### PR TITLE
fix: align Discord fixture hooks

### DIFF
--- a/crabpot.config.json
+++ b/crabpot.config.json
@@ -434,7 +434,7 @@
       "source": {
         "repo": "https://github.com/openclaw/openclaw.git",
         "path": "extensions/discord",
-        "ref": "2ce6b77205187c76ce7cde6cb0913de14d4452fa"
+        "ref": "2e08f0f4221f522b60423ed6ffd83427942b28de"
       },
       "path": "plugins/discord",
       "priority": "medium",
@@ -448,8 +448,7 @@
       "expect": {
         "hooks": [
           "subagent_delivery_target",
-          "subagent_ended",
-          "subagent_spawning"
+          "subagent_ended"
         ],
         "registrations": [
           "registerChannel"

--- a/plugins/discord/package-lock.json
+++ b/plugins/discord/package-lock.json
@@ -8,14 +8,488 @@
       "name": "@crabpot/fixture-discord",
       "version": "0.0.0",
       "dependencies": {
-        "@openclaw/discord": "2026.3.13"
+        "@openclaw/discord": "2026.6.1"
       }
     },
     "node_modules/@openclaw/discord": {
-      "version": "2026.3.13",
-      "resolved": "https://registry.npmjs.org/@openclaw/discord/-/discord-2026.3.13.tgz",
-      "integrity": "sha512-uYCzMmpYVhFPD0TstMmnTNBk9N3Uk/VsZivjr8V/B7g7ajI5HPgsiHBjCLrTmmJZKsVnauo0pAIx/aBcKejYpQ==",
-      "deprecated": "Deprecated: obsolete OpenClaw plugin package version. Use current OpenClaw bundled/plugin distribution; newer npm releases may return later."
+      "version": "2026.6.1",
+      "resolved": "https://registry.npmjs.org/@openclaw/discord/-/discord-2026.6.1.tgz",
+      "integrity": "sha512-zOcdV+e9UbfIvKFm/oMqx1xyt3s04SVOjndCFnb6B4KGUQ7fPARpOxQpQr+dusn6OyXCG5T+PgkiLqRKf/NHMg==",
+      "bundleDependencies": [
+        "@discordjs/voice",
+        "discord-api-types",
+        "libopus-wasm",
+        "typebox",
+        "undici",
+        "ws"
+      ],
+      "hasShrinkwrap": true,
+      "dependencies": {
+        "@discordjs/voice": "0.19.2",
+        "discord-api-types": "0.38.48",
+        "libopus-wasm": "0.2.0",
+        "typebox": "1.1.39",
+        "undici": "8.3.0",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.6.1"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@discordjs/voice": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.2.tgz",
+      "integrity": "sha512-3yJ255e4ag3wfZu/DSxeOZK1UtnqNxnspmLaQetGT0pDkThNZoHs+Zg6dgZZ19JEVomXygvfHn9lNpICZuYtEA==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@snazzah/davey": "^0.1.9",
+        "@types/ws": "^8.18.1",
+        "discord-api-types": "^0.38.41",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.8.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey/-/davey-0.1.11.tgz",
+      "integrity": "sha512-oBN+msHzPnm1M5DDx3wVD7iBwpNXFUtkh2MrAbUJu0OhKjliLChi28hq++mu1+qdMpAVQO5JKAvQQxYVbyneiw==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Snazzah"
+      },
+      "optionalDependencies": {
+        "@snazzah/davey-android-arm-eabi": "0.1.11",
+        "@snazzah/davey-android-arm64": "0.1.11",
+        "@snazzah/davey-darwin-arm64": "0.1.11",
+        "@snazzah/davey-darwin-x64": "0.1.11",
+        "@snazzah/davey-freebsd-x64": "0.1.11",
+        "@snazzah/davey-linux-arm-gnueabihf": "0.1.11",
+        "@snazzah/davey-linux-arm64-gnu": "0.1.11",
+        "@snazzah/davey-linux-arm64-musl": "0.1.11",
+        "@snazzah/davey-linux-x64-gnu": "0.1.11",
+        "@snazzah/davey-linux-x64-musl": "0.1.11",
+        "@snazzah/davey-wasm32-wasi": "0.1.11",
+        "@snazzah/davey-win32-arm64-msvc": "0.1.11",
+        "@snazzah/davey-win32-ia32-msvc": "0.1.11",
+        "@snazzah/davey-win32-x64-msvc": "0.1.11"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-android-arm-eabi": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm-eabi/-/davey-android-arm-eabi-0.1.11.tgz",
+      "integrity": "sha512-T1RYbNYKN6tLOcGIDKJd8OI6FBSEemwL7DOYdTMmhqfhhMr3YVN8WOhfoxGg63OcnpTN2e2c5tdY2bAx25RmQQ==",
+      "cpu": [
+        "arm"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-android-arm64": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm64/-/davey-android-arm64-0.1.11.tgz",
+      "integrity": "sha512-ksJn/x2VU8h6w9eku1HT96ugSRZ7lKVkKNKbFleaFN+U99DJaPM+gMu2YvnFU4V54HR06ZBnRihnVG6VLXQpDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-darwin-arm64": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-arm64/-/davey-darwin-arm64-0.1.11.tgz",
+      "integrity": "sha512-E1d7PbaaVMO3Lj9EiAPqOVbuV0xg5+PsHzHH097DDXiD1+zUDXvJaTnUWsnm5z50pJniHpi4GtaYmk+ieB/guA==",
+      "cpu": [
+        "arm64"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-darwin-x64": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-x64/-/davey-darwin-x64-0.1.11.tgz",
+      "integrity": "sha512-Tl4TI/LTmgJZepgbgVMYDi8RqlAkPtPg1OEBPl7a9Tn3AwR36Vs6lyIT1cs/lGy/ds/+B+mKI4rPObN1cyILTw==",
+      "cpu": [
+        "x64"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-freebsd-x64": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-freebsd-x64/-/davey-freebsd-x64-0.1.11.tgz",
+      "integrity": "sha512-T8Iw9FXkuI1T+YBAFzh9v/TXf9IOTOSqnd/BFpTRTrlW72PR2lhIidzSmg027VxO7r5pX47iFwiOkb9I/NU/EA==",
+      "cpu": [
+        "x64"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-linux-arm-gnueabihf": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm-gnueabihf/-/davey-linux-arm-gnueabihf-0.1.11.tgz",
+      "integrity": "sha512-1Txj+8pqA8uq/OGtaUaBFWAPnNMQzFgIywj0iA7EI4xZl+mab48/pv+YZ1pNb/suC6ynsW44oB9efiXSdcUAgA==",
+      "cpu": [
+        "arm"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-linux-arm64-gnu": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-gnu/-/davey-linux-arm64-gnu-0.1.11.tgz",
+      "integrity": "sha512-ERzF5nM/IYW1BcN3wLXpEwBCGLFf0kGJUVhaV6yfiInz0tkU8UmvrrgpaMaACfMjIhfWdq5CcX+aTkXo/saNcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "inBundle": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-linux-arm64-musl": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-musl/-/davey-linux-arm64-musl-0.1.11.tgz",
+      "integrity": "sha512-e6pX6Hiabtz99q+H/YHNkm9JVlpqN8HGh0qPib8G2+UY4/SSH8WvqWipk3v581dMy2oyCHt7MOoY1aU1P1N/xA==",
+      "cpu": [
+        "arm64"
+      ],
+      "inBundle": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-linux-x64-gnu": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-gnu/-/davey-linux-x64-gnu-0.1.11.tgz",
+      "integrity": "sha512-TW5bSoqChOJMbvsDb4wAATYrxmAXuNnse7wFNVSAJUaZKSeRfZbu3UAiPWSNn7GwLwSfU6hg322KZUn8IWCuvg==",
+      "cpu": [
+        "x64"
+      ],
+      "inBundle": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-linux-x64-musl": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-musl/-/davey-linux-x64-musl-0.1.11.tgz",
+      "integrity": "sha512-5j6Pmc+Wzv5lSxVP6quA7teYRJXibkZqQyYGfTDnTsUOO5dPpcojpqlXlkhyvsA1OAQTj4uxbOCciN3cVWwzug==",
+      "cpu": [
+        "x64"
+      ],
+      "inBundle": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-wasm32-wasi": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-wasm32-wasi/-/davey-wasm32-wasi-0.1.11.tgz",
+      "integrity": "sha512-rKOwZ/0J8lp+4VEyOdMDBRP9KR+PksZpa9V1Qn0veMzy4FqTVKthkxwGqewheFe0SFg9fdvt798l/PBFrfDeZw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-win32-arm64-msvc": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-arm64-msvc/-/davey-win32-arm64-msvc-0.1.11.tgz",
+      "integrity": "sha512-5fptJU4tX901m3mj0SHiBljMrPT4ZEsynbBhR7bK1yn9TY1jjyhN8EFi7QF5IWtUEni+0mia2BCMHZ5ZkmFZqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-win32-ia32-msvc": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-ia32-msvc/-/davey-win32-ia32-msvc-0.1.11.tgz",
+      "integrity": "sha512-ualexn8SeLsiMHhWfzVrzRcjHgcBapg++FPaVgJJxoh2S/jCRiklXOu3luqIZdJdNKvhe2V9SwO/cImPeIIBKw==",
+      "cpu": [
+        "ia32"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@snazzah/davey-win32-x64-msvc": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-x64-msvc/-/davey-win32-x64-msvc-0.1.11.tgz",
+      "integrity": "sha512-muNhc8UKXtknzsH/w4AIkbPR2I8BuvApn0pDXar0IEvY8PCjqU/M8MPbOOEYwQVvQRMwVTgExtxzrkBPSXB4nA==",
+      "cpu": [
+        "x64"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/discord-api-types": {
+      "version": "0.38.48",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.48.tgz",
+      "integrity": "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==",
+      "inBundle": true,
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/@openclaw/discord/node_modules/libopus-wasm": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/libopus-wasm/-/libopus-wasm-0.2.0.tgz",
+      "integrity": "sha512-x/2Gu1/C6L3IICY09zyfp984AWiOYjn53u4WfdY3yh+3KTzMN8Xkm77q3lenWMVIk5SnSzjGEkQT+VQMFHLBHQ==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/prism-media": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "inBundle": true,
+      "license": "0BSD"
+    },
+    "node_modules/@openclaw/discord/node_modules/typebox": {
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.39.tgz",
+      "integrity": "sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w==",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@openclaw/discord/node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@openclaw/discord/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@openclaw/discord/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/plugins/discord/package.json
+++ b/plugins/discord/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Crabpot npm fixture shim for OpenClaw Discord channel plugin.",
   "dependencies": {
-    "@openclaw/discord": "2026.3.13"
+    "@openclaw/discord": "2026.6.1"
   },
   "crabpot": {
     "fixture": "discord",
@@ -12,6 +12,6 @@
     "package": "@openclaw/discord",
     "sourceRepo": "https://github.com/openclaw/openclaw.git",
     "sourcePath": "extensions/discord",
-    "sourceRef": "2ce6b77205187c76ce7cde6cb0913de14d4452fa"
+    "sourceRef": "2e08f0f4221f522b60423ed6ffd83427942b28de"
   }
 }

--- a/scripts/synthetic-probes.mjs
+++ b/scripts/synthetic-probes.mjs
@@ -12,6 +12,16 @@ export const defaultSyntheticProbeMarkdownPath = path.join(repoRoot, "reports/cr
 const pluginInspector = await loadPluginInspectorPublicApi();
 
 const httpRouteDescriptorInputReason = "captured HTTP route probe requires route descriptor input";
+const crabpotSyntheticHookEvents = {
+  ...(pluginInspector.defaultSyntheticHookEvents ?? {}),
+  subagent_ended: {
+    ...(pluginInspector.defaultSyntheticHookEvents?.subagent_ended ?? {}),
+    targetSessionKey: "child-session",
+    targetKind: "subagent",
+    reason: "completed",
+    sendFarewell: false,
+  },
+};
 const crabpotMetadataOnlyRegistrars = new Map([
   [
     "registerEmbeddingProvider",
@@ -170,7 +180,10 @@ function parseArgs(argv) {
 export async function buildSyntheticProbePlan(options = {}) {
   const report = options.report ?? (options.capture ? null : await buildReport({ openclawPath: options.openclawPath }));
   return applyCrabpotSyntheticProbePlanPolicy(
-    pluginInspector.buildSyntheticProbePlanFromReport(report, { capture: options.capture }),
+    pluginInspector.buildSyntheticProbePlanFromReport(report, {
+      capture: options.capture,
+      hookEvents: mergeHookEvents(options.hookEvents),
+    }),
   );
 }
 
@@ -187,6 +200,7 @@ export async function writeSyntheticProbePlan(plan, options = {}) {
 export async function runCapturedSyntheticProbes(capture, options = {}) {
   const result = await pluginInspector.runCapturedSyntheticProbes(capture, {
     ...options,
+    hookEvents: mergeHookEvents(options.hookEvents),
     registrationProbeInputs: mergeRegistrationProbeInputs(options.registrationProbeInputs),
     syntheticSource: "crabpot.synthetic",
   });
@@ -213,6 +227,7 @@ export async function runEntrypointSyntheticProbes(entrypoint, options = {}) {
       ...(options.apiOptions ?? {}),
       retainHandlers: true,
     },
+    hookEvents: mergeHookEvents(options.hookEvents),
     registrationProbeInputs: mergeRegistrationProbeInputs(options.registrationProbeInputs),
     syntheticSource: "crabpot.synthetic",
   });
@@ -389,6 +404,17 @@ function mergeRegistrationProbeInputs(inputs = {}) {
     registerHttpRoute: {
       ...crabpotRegistrationProbeInputs.registerHttpRoute,
       ...(inputs.registerHttpRoute ?? {}),
+    },
+  };
+}
+
+function mergeHookEvents(events = {}) {
+  return {
+    ...crabpotSyntheticHookEvents,
+    ...events,
+    subagent_ended: {
+      ...crabpotSyntheticHookEvents.subagent_ended,
+      ...(events.subagent_ended ?? {}),
     },
   };
 }

--- a/test/synthetic-probes.test.mjs
+++ b/test/synthetic-probes.test.mjs
@@ -11,6 +11,7 @@ import {
   applyFixtureSyntheticFailurePolicy,
   buildSyntheticProbePlan,
   renderSyntheticProbeMarkdown,
+  runCapturedSyntheticProbes,
   validateSyntheticProbePlan,
 } from "../scripts/synthetic-probes.mjs";
 
@@ -178,6 +179,32 @@ test("synthetic probe CLI keeps HTTP route handlers blocked without route descri
   assert.equal(probes.summary.blockedCount, 1);
   assert.equal(probes.results[0].status, "blocked");
   assert.equal(probes.results[0].blockedBy, "http-route-descriptor-input");
+});
+
+test("synthetic probes send subagent_ended target session keys", async () => {
+  const seen = [];
+  const result = await runCapturedSyntheticProbes({
+    entrypoint: path.join(repoRoot, ".crabpot/workspaces/discord/index.js"),
+    status: "captured",
+    captured: [
+      {
+        kind: "hook",
+        name: "subagent_ended",
+      },
+    ],
+    retained: [
+      {
+        captureIndex: 0,
+        handler(event) {
+          seen.push(event);
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(result.summary, { probeCount: 1, passCount: 1, failCount: 0, blockedCount: 0 });
+  assert.equal(seen[0].targetSessionKey, "child-session");
+  assert.equal(seen[0].targetKind, "subagent");
 });
 
 test("fixture execution policy classifies known live tool failures as blocked", () => {


### PR DESCRIPTION
## Summary

- Problem: Current CI was failing static checks because Crabpot still expected the Discord fixture to register deprecated `subagent_spawning`, but current OpenClaw moved thread-bound subagent routing into core session-binding adapters.
- What changed: Updated the Discord fixture source ref to `2e08f0f4221f522b60423ed6ffd83427942b28de`, removed `subagent_spawning` from its expected hooks, and updated the tracked Discord npm fixture shim to `@openclaw/discord@2026.6.1` so package-mode and source-pack mode agree.
- What this does not cover: It does not add a new negative/exact-hook assertion for deprecated hooks; this only aligns the existing positive fixture expectation with the current upstream contract.

## Fixture impact

- [x] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [ ] Changes contract/smoke logic
- [ ] Docs only

## Verification

- [ ] `npm test`
- [x] `node scripts/sync-fixtures.mjs --check`
- [x] `node scripts/run-contract-smoke.mjs`
- [x] strict fixture smoke, if submodules were materialized

Additional proof:

- `node scripts/sync-fixtures.mjs --materialize --no-package-availability-report --openclaw /Users/phaedrus/Projects/openclaw && node --test --test-concurrency=1 test/fixture-inspection.test.mjs test/contract-coverage.test.mjs test/report.test.mjs`
- `node scripts/run-static-suite.mjs --policy dashboard --openclaw /Users/phaedrus/Projects/openclaw`
- `node scripts/sync-fixtures.mjs --materialize --fixture-set discord --plugin-track manifest --no-package-availability-report --openclaw /Users/phaedrus/Projects/openclaw && CRABPOT_FIXTURE_SET=discord node scripts/inspect-fixtures.mjs --check`
- `node scripts/sync-fixtures.mjs --materialize --fixture-set discord --plugin-track source-pack --no-package-availability-report --openclaw /Users/phaedrus/Projects/openclaw && CRABPOT_FIXTURE_SET=discord node scripts/inspect-fixtures.mjs --check`
- `autoreview --mode local --no-web-search --parallel-tests "node --test --test-concurrency=1 test/fixture-inspection.test.mjs test/contract-coverage.test.mjs test/report.test.mjs"`

## Notes

No external services, secrets, or live checks were used beyond GitHub Actions log inspection for the failing run. `npm test` was not run end-to-end because the dashboard static suite covers the failing CI lane and includes the full `node --test test/*.test.mjs` phase plus the relevant contract/report checks.
