### PR TITLE
chore(deps): update NemoClaw fixture to v0.0.62

### DIFF
--- a/reports/crabpot-issues.md
+++ b/reports/crabpot-issues.md
@@ -638,7 +638,7 @@ _none_
   - **before-tool-call-probe**: nemoclaw: before_tool_call needs terminal/block/approval probes
   - state: open · compat:active
   - evidence:
-    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L383)
+    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L383)
 
 - 🟠 P1 **openclaw-telemetry** `inspector-gap` `inspector-follow-up`
   - **before-tool-call-probe**: openclaw-telemetry: before_tool_call needs terminal/block/approval probes
@@ -1419,22 +1419,22 @@ _none_
   - **package-build-artifact-entrypoint**: nemoclaw: cold import requires package build output
   - state: open · compat:none
   - evidence:
-    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/dist/index.js)
+    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/dist/index.js)
 
 - 🟡 P2 **nemoclaw** `inspector-gap` `inspector-follow-up`
   - **package-dependency-install-required**: nemoclaw: cold import requires dependency installation in an isolated workspace
   - state: open · compat:none
   - evidence:
-    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
+    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
 
 - 🟡 P2 **nemoclaw** `inspector-gap` `inspector-follow-up`
   - **registration-capture-gap**: nemoclaw: runtime registrations need capture evidence before final contract judgment
   - state: open · compat:active
   - evidence:
-    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L346)
+    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L346)
 
 - 🟡 P2 **nextcloud-talk** `inspector-gap` `inspector-follow-up`
   - **channel-contract-probe**: nextcloud-talk: channel runtime needs envelope/config probes
@@ -2673,7 +2673,7 @@ _none_
   - **before-tool-call-probe**: nemoclaw: before_tool_call needs terminal/block/approval probes
   - state: open · compat:active
   - evidence:
-    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L383)
+    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L383)
 
 - 🟠 P1 **openclaw-telemetry** `inspector-gap` `inspector-follow-up`
   - **before-tool-call-probe**: openclaw-telemetry: before_tool_call needs terminal/block/approval probes
@@ -4302,22 +4302,22 @@ _none_
   - **package-build-artifact-entrypoint**: nemoclaw: cold import requires package build output
   - state: open · compat:none
   - evidence:
-    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/dist/index.js)
+    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/dist/index.js)
 
 - 🟡 P2 **nemoclaw** `inspector-gap` `inspector-follow-up`
   - **package-dependency-install-required**: nemoclaw: cold import requires dependency installation in an isolated workspace
   - state: open · compat:none
   - evidence:
-    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
+    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
 
 - 🟡 P2 **nemoclaw** `inspector-gap` `inspector-follow-up`
   - **registration-capture-gap**: nemoclaw: runtime registrations need capture evidence before final contract judgment
   - state: open · compat:active
   - evidence:
-    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L346)
+    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L346)
 
 - 🟡 P2 **nextcloud-talk** `inspector-gap` `inspector-follow-up`
   - **channel-contract-probe**: nextcloud-talk: channel runtime needs envelope/config probes
@@ -5125,7 +5125,7 @@ _none_
   - contract: Hook returns preserve terminal, block, and approval semantics.
   - id: `hook.before_tool_call.terminal-block-approval:nemoclaw`
   - evidence:
-    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L383)
+    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L383)
 
 - 🟠 P1 **openclaw-telemetry** `hook-runner`
   - contract: Hook returns preserve terminal, block, and approval semantics.
@@ -5335,7 +5335,7 @@ _none_
   - contract: External inspector capture records service, route, gateway, command, and interactive registrations.
   - id: `api.capture.runtime-registrars:nemoclaw`
   - evidence:
-    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L346)
+    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L346)
 
 - 🟡 P2 **openclaw-telemetry** `inspector-capture-api`
   - contract: External inspector capture records service, route, gateway, command, and interactive registrations.
@@ -5634,7 +5634,7 @@ _none_
   - contract: Inspector can build or resolve source aliases before cold importing package entrypoints.
   - id: `package.entrypoint.build-before-cold-import:nemoclaw`
   - evidence:
-    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/dist/index.js)
+    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/dist/index.js)
 
 - 🟡 P2 **opik-openclaw** `package-loader`
   - contract: Inspector can build or resolve source aliases before cold importing package entrypoints.
@@ -5750,10 +5750,10 @@ _none_
   - contract: Inspector installs package dependencies in an isolated workspace before cold import.
   - id: `package.entrypoint.isolated-dependency-install:nemoclaw`
   - evidence:
-    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
+    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
 
 - 🟡 P2 **openclaw-weixin** `package-loader`
   - contract: Inspector installs package dependencies in an isolated workspace before cold import.

--- a/reports/crabpot-report.md
+++ b/reports/crabpot-report.md
@@ -644,7 +644,7 @@ _none_
   - **before-tool-call-probe**: nemoclaw: before_tool_call needs terminal/block/approval probes
   - state: open · compat:active
   - evidence:
-    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L383)
+    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L383)
 
 - 🟠 P1 **openclaw-telemetry** `inspector-gap` `inspector-follow-up`
   - **before-tool-call-probe**: openclaw-telemetry: before_tool_call needs terminal/block/approval probes
@@ -1425,22 +1425,22 @@ _none_
   - **package-build-artifact-entrypoint**: nemoclaw: cold import requires package build output
   - state: open · compat:none
   - evidence:
-    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/dist/index.js)
+    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/dist/index.js)
 
 - 🟡 P2 **nemoclaw** `inspector-gap` `inspector-follow-up`
   - **package-dependency-install-required**: nemoclaw: cold import requires dependency installation in an isolated workspace
   - state: open · compat:none
   - evidence:
-    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
+    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
 
 - 🟡 P2 **nemoclaw** `inspector-gap` `inspector-follow-up`
   - **registration-capture-gap**: nemoclaw: runtime registrations need capture evidence before final contract judgment
   - state: open · compat:active
   - evidence:
-    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L346)
+    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L346)
 
 - 🟡 P2 **nextcloud-talk** `inspector-gap` `inspector-follow-up`
   - **channel-contract-probe**: nextcloud-talk: channel runtime needs envelope/config probes
@@ -3005,7 +3005,7 @@ _none_
   - **before-tool-call-probe**: nemoclaw: before_tool_call needs terminal/block/approval probes
   - state: open · compat:active
   - evidence:
-    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L383)
+    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L383)
 
 - 🟠 P1 **openclaw-telemetry** `inspector-gap` `inspector-follow-up`
   - **before-tool-call-probe**: openclaw-telemetry: before_tool_call needs terminal/block/approval probes
@@ -4634,22 +4634,22 @@ _none_
   - **package-build-artifact-entrypoint**: nemoclaw: cold import requires package build output
   - state: open · compat:none
   - evidence:
-    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/dist/index.js)
+    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/dist/index.js)
 
 - 🟡 P2 **nemoclaw** `inspector-gap` `inspector-follow-up`
   - **package-dependency-install-required**: nemoclaw: cold import requires dependency installation in an isolated workspace
   - state: open · compat:none
   - evidence:
-    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
+    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
 
 - 🟡 P2 **nemoclaw** `inspector-gap` `inspector-follow-up`
   - **registration-capture-gap**: nemoclaw: runtime registrations need capture evidence before final contract judgment
   - state: open · compat:active
   - evidence:
-    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L346)
+    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L346)
 
 - 🟡 P2 **nextcloud-talk** `inspector-gap` `inspector-follow-up`
   - **channel-contract-probe**: nextcloud-talk: channel runtime needs envelope/config probes
@@ -5457,7 +5457,7 @@ _none_
   - contract: Hook returns preserve terminal, block, and approval semantics.
   - id: `hook.before_tool_call.terminal-block-approval:nemoclaw`
   - evidence:
-    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L383)
+    - [before_tool_call @ index.ts:383](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L383)
 
 - 🟠 P1 **openclaw-telemetry** `hook-runner`
   - contract: Hook returns preserve terminal, block, and approval semantics.
@@ -5667,7 +5667,7 @@ _none_
   - contract: External inspector capture records service, route, gateway, command, and interactive registrations.
   - id: `api.capture.runtime-registrars:nemoclaw`
   - evidence:
-    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/src/index.ts#L346)
+    - [registerCommand @ index.ts:346](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/src/index.ts#L346)
 
 - 🟡 P2 **openclaw-telemetry** `inspector-capture-api`
   - contract: External inspector capture records service, route, gateway, command, and interactive registrations.
@@ -5966,7 +5966,7 @@ _none_
   - contract: Inspector can build or resolve source aliases before cold importing package entrypoints.
   - id: `package.entrypoint.build-before-cold-import:nemoclaw`
   - evidence:
-    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/dist/index.js)
+    - [extension:./dist/index.js @ index.js](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/dist/index.js)
 
 - 🟡 P2 **opik-openclaw** `package-loader`
   - contract: Inspector can build or resolve source aliases before cold importing package entrypoints.
@@ -6082,10 +6082,10 @@ _none_
   - contract: Inspector installs package dependencies in an isolated workspace before cold import.
   - id: `package.entrypoint.isolated-dependency-install:nemoclaw`
   - evidence:
-    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
-    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/16470fa026f0a5218b609cf97d3751bdb7147818/nemoclaw/package.json)
+    - [execa @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [json5 @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [tar @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
+    - [yaml @ package.json](https://github.com/NVIDIA/NemoClaw/blob/8827570b919b278a0c05356944dedd8ef810f656/nemoclaw/package.json)
 
 - 🟡 P2 **openclaw-weixin** `package-loader`
   - contract: Inspector installs package dependencies in an isolated workspace before cold import.


### PR DESCRIPTION
Replaces https://github.com/openclaw/crabpot/pull/155 because the Dependabot head is not maintainer-writable and the generated reports need refreshing.

Changes:
- update the NemoClaw fixture from v0.0.61 to immutable v0.0.62 commit 8827570b919b278a0c05356944dedd8ef810f656
- refresh owned report source links

Verification:
- upstream plugin package: npm ci --ignore-scripts, build, check, 482 tests, package dry-run
- production dependency audit: zero findings; one unchanged moderate PostCSS advisory is dev-only through Vitest/Vite
- exact isolated workspace proof: five steps, zero failures; four registration/hook probes passed
- full Crabpot static suite: 19/19 steps passed, including 156 tests and three-run profiles
- Codex autoreview: clean

Original author: dependabot[bot].
