### PR TITLE
chore: align pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -63,3 +63,21 @@ changes when it clarifies the result.
 Reviewers will inspect the code, tests, and CI. Use this section to make the
 validation easy to understand, not to restate the diff.
 -->
+
+## Fixture Impact
+
+- [ ] Adds or updates fixture manifest entries
+- [ ] Updates submodule pins
+- [ ] Changes contract or smoke logic
+- [ ] Docs only
+
+## Fixture Verification
+
+- [ ] `npm test`
+- [ ] `node scripts/sync-fixtures.mjs --check`
+- [ ] `node scripts/run-contract-smoke.mjs`
+- [ ] Strict fixture smoke, if submodules were materialized
+
+## Notes
+
+<!-- List any external services, secrets, or live checks intentionally skipped. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,65 @@
-## Summary
+<!--
+Optional linked context:
+Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
+below this comment.
 
-- Problem:
-- What changed:
-- What this does not cover:
+Required PR title:
+type: user-facing description
+Use a parenthesized scope only when it adds clarity:
+fix(auth): login redirect loops when session cookie is expired
 
-## Fixture impact
+Types: feat, fix, improve, refactor, docs, chore.
+For fixes, describe the user-visible symptom and trigger:
+fix: task list fails to load when user has no environments
+Avoid implementation details such as:
+fix: add null check to task query
+-->
 
-- [ ] Adds or updates fixture manifest entries
-- [ ] Updates submodule pins
-- [ ] Changes contract/smoke logic
-- [ ] Docs only
+<details>
+<summary>Additional instructions</summary>
 
-## Verification
+**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
+can help update the branch when needed.
 
-- [ ] `npm test`
-- [ ] `node scripts/sync-fixtures.mjs --check`
-- [ ] `node scripts/run-contract-smoke.mjs`
-- [ ] strict fixture smoke, if submodules were materialized
+</details>
 
-## Notes
+## What Problem This Solves
 
-List any external services, secrets, or live checks intentionally skipped.
+<!--
+Describe the concrete user, product, or operational problem.
+For fixes, begin with:
+"Fixes an issue where users <do X> would <experience Y> when <condition>."
+or:
+"Resolves a problem where..."
 
+Name the affected UI surface or workflow. Do not describe the code-level cause here.
+-->
+
+## Why This Change Was Made
+
+<!--
+In one or two sentences, explain the complete shipped solution, key design
+decisions, and relevant boundaries or non-goals. Include implementation detail
+only when it helps reviewers understand user-visible behavior or risk.
+Avoid file-by-file narration.
+-->
+
+## User Impact
+
+<!--
+State what users, operators, or developers can now do or expect. Lead with the
+concrete benefit and use user-facing language. If there is no user-visible
+impact, say so plainly.
+-->
+
+## Evidence
+
+<!--
+Show the most useful proof that this change works. Screenshots, screencasts,
+terminal output, focused tests, CI results, live observations, redacted logs,
+and artifact links are all useful. Include before/after evidence for visual
+changes when it clarifies the result.
+
+Reviewers will inspect the code, tests, and CI. Use this section to make the
+validation easy to understand, not to restate the diff.
+-->


### PR DESCRIPTION
## What Problem This Solves

Resolves inconsistent pull request descriptions across OpenClaw-owned repositories without removing Crabpot's fixture-specific review prompts.

## Why This Change Was Made

Adopts the canonical PR body structure from `openclaw/openclaw` at pinned commit `2ac723282c84286ad3f38aabbd2e70699aafb3c3`, then retains the repository's fixture-impact, fixture-verification, and skipped-check guidance.

## User Impact

Contributors get the shared problem, rationale, impact, and evidence sections while maintainers retain Crabpot's fixture review checklist; no runtime behavior changes.

## Evidence

- Canonical source blob: `e902c4789b21765ea16dfb75e436db5801b6450b` at `openclaw/openclaw@2ac723282c84286ad3f38aabbd2e70699aafb3c3`.
- The first 65 lines match canonical SHA-256 `38845d7f2cfc96402062408ac8a87b1e3f5f81dd80924785b0547b64a0c914b6`.
- Preserved all eight prior fixture-impact and fixture-verification prompts plus the skipped-check notes field.
- `git diff --check` passed.
- Metadata-only change; runtime tests are not applicable.
- AI-assisted batch maintenance change.
