### PR TITLE
fix(fixtures): align Codex provider contract

### DIFF
--- a/crabpot.config.json
+++ b/crabpot.config.json
@@ -870,7 +870,7 @@
     },
     {
       "id": "codex",
-      "name": "OpenClaw Codex harness and model provider plugin",
+      "name": "OpenClaw Codex harness plugin",
       "package": {
         "name": "@openclaw/codex",
         "tag": "beta"
@@ -878,7 +878,7 @@
       "source": {
         "repo": "https://github.com/openclaw/openclaw.git",
         "path": "extensions/codex",
-        "ref": "a22f06504376e7203a2bec8fde094b7cdcb06c02"
+        "ref": "d45e024dcabfd01abec24bf195fc2a6f0984cfef"
       },
       "path": "plugins/codex",
       "priority": "medium",
@@ -899,14 +899,15 @@
           "registerCommand",
           "registerMediaUnderstandingProvider",
           "registerMigrationProvider",
-          "registerProvider"
+          "registerWebSearchProvider"
         ],
         "manifestContracts": [
           "mediaUnderstandingProviders",
-          "migrationProviders"
+          "migrationProviders",
+          "webSearchProviders"
         ]
       },
-      "why": "Official Codex package covering agent harness registration, model provider wiring, media understanding, migrations, inbound claims, and npm artifact packaging."
+      "why": "Official Codex package covering agent harness registration, hosted web search, media understanding, migrations, inbound claims, and npm artifact packaging."
     },
     {
       "id": "diagnostics-prometheus",

--- a/test/manifest.test.mjs
+++ b/test/manifest.test.mjs
@@ -51,6 +51,16 @@ test("openclaw beta fixture set narrows to beta npm packages", async () => {
   assert.ok(manifest.fixtures.every((fixture) => fixture.package?.tag === "beta"));
 });
 
+test("Codex fixture follows current provider ownership", async () => {
+  const manifest = await readManifest();
+  const codex = manifest.fixtures.find((fixture) => fixture.id === "codex");
+
+  assert.ok(codex);
+  assert.ok(codex.expect.registrations.includes("registerWebSearchProvider"));
+  assert.equal(codex.expect.registrations.includes("registerProvider"), false);
+  assert.ok(codex.expect.manifestContracts.includes("webSearchProviders"));
+});
+
 test("bundled OpenClaw channels source-pack from the monorepo", async () => {
   const manifest = await readManifest();
   const bundled = manifest.fixtures.filter((fixture) => ["matrix", "mattermost"].includes(fixture.id));


### PR DESCRIPTION
## Summary

- align the Codex fixture with upstream text-provider ownership moving to OpenAI
- require Codex hosted web-search registration and manifest ownership
- lock the expected provider contract with a regression test

## Proof

- `npm run check:contracts`
- `node --test test/manifest.test.mjs`
- `CRABPOT_FIXTURE_SET=codex node scripts/inspect-fixtures.mjs --check` against OpenClaw `d45e024dcabfd01abec24bf195fc2a6f0984cfef`
- AutoReview clean
