### PR TITLE
fix: parse current OpenClaw hook surface

### DIFF
--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
-export const pluginInspectorRef = "96bbf7ac2fbb662be457b38bbd7ad6b228e16892";
+export const pluginInspectorRef = "860206df74ca6c4e000117e44f3c9fbdf3cbcf34";
 export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.16";
 
 export async function loadPluginInspector() {


### PR DESCRIPTION
## Summary

- update the pinned plugin-inspector source to the parser fix landed in openclaw/plugin-inspector#46
- restore OpenClaw target hook parsing for the current private `PLUGIN_HOOK_NAMES` declaration
- keep the published package pin unchanged because this target parser path loads the pinned source API

## Proof

- plugin-inspector: `npm test` (206 passed)
- plugin-inspector regression uses current `as const satisfies readonly PluginHookName[]` source shape
- crabpot: `node --test test/plugin-inspector-source.test.mjs` (3 passed)
- crabpot generated-surface check against current OpenClaw checkout: passed
- AutoReview: clean, no accepted/actionable findings
