### PR TITLE
fix: update plugin inspector capture runtime

### DIFF
--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
-export const pluginInspectorRef = "860206df74ca6c4e000117e44f3c9fbdf3cbcf34";
+export const pluginInspectorRef = "f165eafa2a74dddc2f1fc7e8452e96c223bffd8a";
 export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.16";
 
 export async function loadPluginInspector() {


### PR DESCRIPTION
## Summary

- advance the plugin-inspector source pin to the OpenClaw blob-store runtime mock
- restore Diffs capture against current OpenClaw without changing the published package lane

Upstream: openclaw/plugin-inspector#47

## Proof

- `npm test` (167 tests)
- Diffs source-pack isolated execution: 7/7 steps passed
- Diffs synthetic probes: 1 pass, 2 expected blocked, 0 failures
- AutoReview clean
