### PR TITLE
ci: split OpenClaw compatibility lanes

### DIFF
--- a/.github/openclaw-default-track.json
+++ b/.github/openclaw-default-track.json
@@ -1,0 +1,5 @@
+{
+  "repository": "openclaw/openclaw",
+  "sha": "e3eb1121adfb3eef87200d2964f01396e2b6acbc",
+  "pinnedAt": "2026-07-18"
+}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   manifest:
-    name: Static checks (${{ matrix.os }})
+    name: Default Track / Static checks (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -29,9 +29,9 @@ jobs:
           cache: npm
           cache-dependency-path: |
             plugins/**/package-lock.json
-      - name: Resolve OpenClaw track
+      - name: Resolve pinned OpenClaw Default Track
         id: openclaw-track
-        run: node scripts/resolve-openclaw-track.mjs --github-output
+        run: node scripts/openclaw-pin.mjs --github-output
       - uses: actions/checkout@v6
         with:
           repository: openclaw/openclaw
@@ -70,12 +70,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: crabpot-check-reports-${{ matrix.os }}
+          name: crabpot-default-track-reports-${{ matrix.os }}
           path: reports/
           if-no-files-found: warn
 
   container-smoke:
-    name: Container static checks
+    name: Default Track / Container static checks
     runs-on: ubuntu-latest
     container:
       image: node:22-bookworm
@@ -83,9 +83,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Resolve OpenClaw track
+      - name: Resolve pinned OpenClaw Default Track
         id: openclaw-track
-        run: node scripts/resolve-openclaw-track.mjs --github-output
+        run: node scripts/openclaw-pin.mjs --github-output
       - uses: actions/checkout@v6
         with:
           repository: openclaw/openclaw
@@ -103,7 +103,7 @@ jobs:
           node scripts/run-static-suite.mjs --openclaw ./openclaw --policy dashboard --profile-runs 3 --plugin-inspector-smoke "${extra_args[@]}"
 
   changed-fixture-plan:
-    name: Resolve changed fixture matrix
+    name: Default Track / Resolve changed fixture matrix
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     outputs:
@@ -121,9 +121,9 @@ jobs:
           cache: npm
           cache-dependency-path: |
             plugins/**/package-lock.json
-      - name: Resolve OpenClaw track
+      - name: Resolve pinned OpenClaw Default Track
         id: openclaw-track
-        run: node scripts/resolve-openclaw-track.mjs --github-output
+        run: node scripts/openclaw-pin.mjs --github-output
       - uses: actions/checkout@v6
         with:
           repository: openclaw/openclaw
@@ -167,7 +167,7 @@ jobs:
         run: echo "fixtures=${{ steps.resolve.outputs.fixtures }}"
 
   changed-isolated-fixture:
-    name: Isolated changed fixture ${{ matrix.id }}
+    name: Default Track / Isolated changed fixture ${{ matrix.id }}
     runs-on: ubuntu-latest
     needs: changed-fixture-plan
     if: ${{ needs.changed-fixture-plan.outputs.count != '0' }}
@@ -184,9 +184,9 @@ jobs:
           cache: npm
           cache-dependency-path: |
             plugins/**/package-lock.json
-      - name: Resolve OpenClaw track
+      - name: Resolve pinned OpenClaw Default Track
         id: openclaw-track
-        run: node scripts/resolve-openclaw-track.mjs --github-output
+        run: node scripts/openclaw-pin.mjs --github-output
       - uses: actions/checkout@v6
         with:
           repository: openclaw/openclaw
@@ -239,10 +239,33 @@ jobs:
         if: ${{ steps.policy.outcome == 'failure' }}
         run: exit 1
 
-  dashboard:
+  default-track:
+    name: Default Track (pinned OpenClaw)
     runs-on: ubuntu-latest
     needs: [manifest, container-smoke, changed-fixture-plan, changed-isolated-fixture]
-    if: ${{ always() && github.event_name != 'pull_request' && github.actor != 'github-actions[bot]' && needs.manifest.result == 'success' && needs.container-smoke.result == 'success' && (needs.changed-isolated-fixture.result == 'success' || needs.changed-isolated-fixture.result == 'skipped') }}
+    if: always()
+    steps:
+      - name: Require every pinned lane
+        env:
+          MANIFEST_RESULT: ${{ needs.manifest.result }}
+          CONTAINER_RESULT: ${{ needs.container-smoke.result }}
+          PLAN_RESULT: ${{ needs.changed-fixture-plan.result }}
+          ISOLATED_RESULT: ${{ needs.changed-isolated-fixture.result }}
+        shell: bash
+        run: |
+          test "${MANIFEST_RESULT}" = success
+          test "${CONTAINER_RESULT}" = success
+          if [ "${PLAN_RESULT}" != success ] && [ "${PLAN_RESULT}" != skipped ]; then
+            exit 1
+          fi
+          if [ "${ISOLATED_RESULT}" != success ] && [ "${ISOLATED_RESULT}" != skipped ]; then
+            exit 1
+          fi
+
+  dashboard:
+    runs-on: ubuntu-latest
+    needs: [default-track]
+    if: ${{ github.event_name != 'pull_request' && github.actor != 'github-actions[bot]' && needs.default-track.result == 'success' }}
     permissions:
       contents: write
     steps:
@@ -255,9 +278,9 @@ jobs:
           cache: npm
           cache-dependency-path: |
             plugins/**/package-lock.json
-      - name: Resolve OpenClaw track
+      - name: Resolve pinned OpenClaw Default Track
         id: openclaw-track
-        run: node scripts/resolve-openclaw-track.mjs --github-output
+        run: node scripts/openclaw-pin.mjs --github-output
       - uses: actions/checkout@v6
         with:
           repository: openclaw/openclaw
@@ -298,7 +321,7 @@ jobs:
           node scripts/compare-runtime-profile.mjs
           node scripts/check-ci-policy.mjs
           node scripts/write-ci-summary.mjs --mode check --openclaw-label "${{ steps.openclaw-track.outputs.label }}"
-          node scripts/update-track-metadata.mjs
+          node scripts/update-track-metadata.mjs --default-pin-openclaw ./openclaw
           baseline_arg=()
           if [ -f .crabpot/baseline/main-dashboard-data.json ]; then
             baseline_arg=(--baseline-data .crabpot/baseline/main-dashboard-data.json)

--- a/.github/workflows/openclaw-head-canary.yml
+++ b/.github/workflows/openclaw-head-canary.yml
@@ -1,0 +1,114 @@
+name: OpenClaw HEAD Canary (Advisory)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-head:
+    name: HEAD Canary / Resolve OpenClaw HEAD
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.openclaw-head.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: openclaw/openclaw
+          ref: main
+      - name: Record OpenClaw HEAD revision
+        id: openclaw-head
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  head-canary:
+    name: HEAD Canary (advisory, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: resolve-head
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            plugins/**/package-lock.json
+      - uses: actions/checkout@v6
+        with:
+          repository: openclaw/openclaw
+          ref: ${{ needs.resolve-head.outputs.sha }}
+          path: openclaw
+      - name: Show OpenClaw HEAD revision
+        shell: bash
+        run: |
+          sha="$(git -C openclaw rev-parse HEAD)"
+          test "${sha}" = "${{ needs.resolve-head.outputs.sha }}"
+          echo "OpenClaw HEAD: ${sha}"
+      - name: Install OpenClaw lifecycle dependencies
+        shell: bash
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./openclaw/package.json').packageManager.split('+')[0]")" --activate
+          pnpm --dir openclaw install --frozen-lockfile --ignore-scripts
+      - name: Check npm latest metadata
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        continue-on-error: true
+        run: node scripts/resolve-openclaw-track.mjs --track latest --warn-missing-tag
+      - name: Run Default Track suite against HEAD
+        shell: bash
+        timeout-minutes: 30
+        run: |
+          node scripts/run-static-suite.mjs \
+            --openclaw ./openclaw \
+            --policy dashboard \
+            --profile-runs 3 \
+            --plugin-inspector-smoke \
+            --openclaw-track latest \
+            --plugin-track latest
+      - name: Write canary reports
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          CRABPOT_OPENCLAW_TRACK: latest
+          CRABPOT_PLUGIN_TRACK: latest
+        run: |
+          report_failed=0
+          run_report() {
+            if "$@"; then
+              return
+            fi
+            echo "::warning::Canary report command failed: $*"
+            report_failed=1
+          }
+          run_report node scripts/generate-report.mjs --openclaw ./openclaw
+          run_report node scripts/capture-contracts.mjs --openclaw ./openclaw
+          run_report node scripts/synthetic-probes.mjs --openclaw ./openclaw
+          run_report node scripts/cold-import-readiness.mjs --openclaw ./openclaw
+          run_report node scripts/workspace-plan.mjs --openclaw ./openclaw
+          run_report node scripts/platform-probes.mjs --openclaw ./openclaw
+          run_report node scripts/check-generated-surface-fixture.mjs --openclaw ./openclaw
+          run_report node scripts/import-loop-profile.mjs --openclaw ./openclaw --runs 3
+          run_report node scripts/profile-contract-runtime.mjs --openclaw ./openclaw --runs 3
+          run_report node scripts/compare-runtime-profile.mjs
+          run_report node scripts/check-ci-policy.mjs
+          run_report node scripts/write-ci-summary.mjs --mode head-canary --openclaw-label "openclaw/openclaw@${{ needs.resolve-head.outputs.sha }}" --github-step-summary
+          exit "${report_failed}"
+      - name: Upload HEAD canary reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crabpot-openclaw-head-canary-${{ matrix.os }}
+          path: reports/
+          if-no-files-found: warn

--- a/.github/workflows/openclaw-pin-age.yml
+++ b/.github/workflows/openclaw-pin-age.yml
@@ -1,0 +1,21 @@
+name: OpenClaw Default Track Pin Age
+
+on:
+  schedule:
+    - cron: "19 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pin-age:
+    name: Default Track pin age (14-day SLA)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Enforce pin age SLA
+        run: node scripts/openclaw-pin.mjs --check-age --max-age-days 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.2 - Unreleased
 
-_No changes yet._
+- Split CI into a required pinned OpenClaw Default Track, an advisory artifact-producing HEAD canary, and a 14-day pin-promotion SLA.
 
 ## 0.2.1 - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,26 @@ the generated reports. The optional isolated job runs one fixture lane when
 `run_isolated_fixture` is enabled and `fixture` is set, then uploads
 `.crabpot/results/` plus the execution summary report.
 
+## Default Track and HEAD canary
+
+Required CI runs the Default Track suite against the immutable OpenClaw SHA in
+`.github/openclaw-default-track.json`. The separately labeled `OpenClaw HEAD
+Canary (Advisory)` workflow runs the same suite against OpenClaw `main`, uploads
+reports for every platform, and never blocks merges. A missing GitHub tag for
+the npm `latest` version is a canary warning, not a required-lane failure. The
+required dashboard records metadata from the pinned checkout and never resolves
+OpenClaw HEAD or requires a matching upstream release tag.
+
+Promote a green canary SHA with one command, then open the resulting focused PR:
+
+```bash
+npm run openclaw:promote -- <40-character-openclaw-sha>
+```
+
+The command validates the OpenClaw commit and updates both the SHA and promotion
+date. The daily `OpenClaw Default Track Pin Age` workflow fails once that date is
+more than 14 days old, prompting another deliberate canary-to-pin promotion.
+
 ## Fixture policy
 
 Fixtures should earn their spot by covering a distinct seam. Popularity is a

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fixtures:sync": "node scripts/sync-fixtures.mjs --materialize",
     "import:profile": "node scripts/import-loop-profile.mjs",
     "import:profile:openclaw": "node scripts/import-loop-profile.mjs --openclaw ../openclaw",
+    "openclaw:promote": "node scripts/openclaw-pin.mjs --promote",
     "plugin-inspector:smoke": "node scripts/run-plugin-inspector-smoke.mjs --check",
     "profile": "node scripts/profile-contract-runtime.mjs",
     "profile:compare": "node scripts/compare-runtime-profile.mjs",

--- a/scripts/openclaw-pin.mjs
+++ b/scripts/openclaw-pin.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { appendFile, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { repoRoot } from "./manifest-lib.mjs";
+
+export const defaultOpenClawPinPath = path.join(repoRoot, ".github/openclaw-default-track.json");
+export const defaultMaxPinAgeDays = 14;
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.promote) {
+    if (!args.sha) {
+      throw new Error("promotion requires the exact green HEAD canary SHA");
+    }
+    const sha = args.sha;
+    await assertOpenClawCommit(sha);
+    const pin = {
+      repository: "openclaw/openclaw",
+      sha,
+      pinnedAt: args.date || new Date().toISOString().slice(0, 10),
+    };
+    validatePin(pin);
+    await writeFile(args.file, `${JSON.stringify(pin, null, 2)}\n`, "utf8");
+    console.log(`promoted Default Track to ${pin.sha} (${pin.pinnedAt})`);
+    return;
+  }
+
+  const pin = await readOpenClawPin(args.file);
+  if (args.checkAge) {
+    const age = pinAgeDays(pin, args.now ? new Date(args.now) : new Date());
+    console.log(`Default Track pin ${pin.sha.slice(0, 12)} age: ${age} day(s); SLA: ${args.maxAgeDays} day(s)`);
+    if (age > args.maxAgeDays) {
+      throw new Error(
+        `Default Track pin is ${age} days old (maximum ${args.maxAgeDays}); promote a green HEAD canary with npm run openclaw:promote`,
+      );
+    }
+  }
+
+  const result = pinOutputs(pin);
+  if (args.githubOutput) {
+    await writeGithubOutput(result);
+    return;
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    checkAge: false,
+    date: "",
+    file: defaultOpenClawPinPath,
+    githubOutput: false,
+    maxAgeDays: defaultMaxPinAgeDays,
+    now: "",
+    promote: false,
+    sha: "",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--check-age") {
+      args.checkAge = true;
+      continue;
+    }
+    if (arg === "--date") {
+      args.date = argv[++index] ?? "";
+      continue;
+    }
+    if (arg === "--file") {
+      args.file = path.resolve(argv[++index] ?? "");
+      continue;
+    }
+    if (arg === "--github-output") {
+      args.githubOutput = true;
+      continue;
+    }
+    if (arg === "--max-age-days") {
+      args.maxAgeDays = Number(argv[++index]);
+      continue;
+    }
+    if (arg === "--now") {
+      args.now = argv[++index] ?? "";
+      continue;
+    }
+    if (arg === "--promote") {
+      args.promote = true;
+      const candidate = argv[index + 1];
+      if (candidate && !candidate.startsWith("--")) {
+        args.sha = candidate;
+        index += 1;
+      }
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!Number.isInteger(args.maxAgeDays) || args.maxAgeDays < 0) {
+    throw new Error("--max-age-days must be a non-negative integer");
+  }
+  return args;
+}
+
+export async function readOpenClawPin(file = defaultOpenClawPinPath) {
+  const pin = JSON.parse(await readFile(file, "utf8"));
+  validatePin(pin);
+  return pin;
+}
+
+export function validatePin(pin) {
+  if (pin?.repository !== "openclaw/openclaw") {
+    throw new Error("Default Track repository must be openclaw/openclaw");
+  }
+  if (!/^[0-9a-f]{40}$/.test(pin.sha ?? "")) {
+    throw new Error("Default Track SHA must be 40 lowercase hexadecimal characters");
+  }
+  const pinnedDate = new Date(`${pin.pinnedAt}T00:00:00Z`);
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(pin.pinnedAt ?? "")
+    || Number.isNaN(pinnedDate.getTime())
+    || pinnedDate.toISOString().slice(0, 10) !== pin.pinnedAt
+  ) {
+    throw new Error("Default Track pinnedAt must be a valid YYYY-MM-DD date");
+  }
+}
+
+export function pinOutputs(pin) {
+  return {
+    label: `${pin.repository}@${pin.sha.slice(0, 12)} (Default Track pin ${pin.pinnedAt})`,
+    pinned_at: pin.pinnedAt,
+    ref: pin.sha,
+    repository: pin.repository,
+    sha: pin.sha,
+    track: "latest",
+  };
+}
+
+export function pinAgeDays(pin, now = new Date()) {
+  validatePin(pin);
+  if (Number.isNaN(now.getTime())) {
+    throw new Error("invalid current date");
+  }
+  const pinnedAt = Date.parse(`${pin.pinnedAt}T00:00:00Z`);
+  if (pinnedAt > now.getTime()) {
+    throw new Error(`Default Track pinnedAt ${pin.pinnedAt} is in the future`);
+  }
+  return Math.floor((now.getTime() - pinnedAt) / 86_400_000);
+}
+
+async function assertOpenClawCommit(sha) {
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error("promotion SHA must be 40 lowercase hexadecimal characters");
+  }
+  const response = await fetch(`https://api.github.com/repos/openclaw/openclaw/commits/${sha}`, {
+    headers: { Accept: "application/vnd.github+json", "User-Agent": "crabpot-openclaw-pin" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(`could not verify OpenClaw commit ${sha}: GitHub returned ${response.status}`);
+  }
+}
+
+async function writeGithubOutput(result) {
+  const output = `${Object.entries(result).map(([key, value]) => `${key}=${value}`).join("\n")}\n`;
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, output, "utf8");
+    return;
+  }
+  process.stdout.write(output);
+}

--- a/scripts/resolve-openclaw-track.mjs
+++ b/scripts/resolve-openclaw-track.mjs
@@ -15,6 +15,14 @@ const branchTracks = new Map([
   ["crab-development", "development"],
 ]);
 
+export class MissingOpenClawTagError extends Error {
+  constructor(version) {
+    super(`OpenClaw GitHub tag v${version} is missing`);
+    this.name = "MissingOpenClawTagError";
+    this.version = version;
+  }
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }
@@ -22,7 +30,16 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const track = normalizeTrack(args.track, args.branch);
-  const result = await resolveOpenClawTrack(track);
+  let result;
+  try {
+    result = await resolveOpenClawTrack(track);
+  } catch (error) {
+    if (args.warnMissingTag && error instanceof MissingOpenClawTagError) {
+      console.log(`::warning::OpenClaw npm ${track} resolves to ${error.version}, but GitHub tag v${error.version} is missing; HEAD canary continues.`);
+      return;
+    }
+    throw error;
+  }
 
   if (args.githubOutput) {
     await writeGithubOutput(result);
@@ -41,6 +58,7 @@ function parseArgs(argv) {
     githubOutput: false,
     json: false,
     track: process.env.CRABPOT_OPENCLAW_TRACK || "auto",
+    warnMissingTag: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -61,6 +79,10 @@ function parseArgs(argv) {
     if (arg === "--track") {
       args.track = argv[index + 1];
       index += 1;
+      continue;
+    }
+    if (arg === "--warn-missing-tag") {
+      args.warnMissingTag = true;
     }
   }
 
@@ -130,7 +152,11 @@ async function tagSha(version) {
   if (peeled) {
     return peeled;
   }
-  return lsRemote(`refs/tags/v${version}`);
+  const direct = await optionalLsRemote(`refs/tags/v${version}`);
+  if (direct) {
+    return direct;
+  }
+  throw new MissingOpenClawTagError(version);
 }
 
 async function optionalLsRemote(ref) {

--- a/scripts/update-track-metadata.mjs
+++ b/scripts/update-track-metadata.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
+import { readOpenClawPin } from "./openclaw-pin.mjs";
 import { normalizeTrack, resolveOpenClawTrack } from "./resolve-openclaw-track.mjs";
 
 export const trackMetadataStart = "<!-- crabpot-tracks:start -->";
@@ -28,13 +29,15 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const tracks = await resolveTrackMetadata();
+  const tracks = args.defaultPinOpenClaw
+    ? [await resolveDefaultPinMetadata(args.defaultPinOpenClaw)]
+    : await resolveTrackMetadata();
   const changed = await updateTrackMetadata({
     branch: args.branch,
     check: args.check,
     readmePath: args.readmePath,
     runUrl: args.runUrl,
-    track: args.track,
+    track: args.defaultPinOpenClaw ? "latest" : args.track,
     tracks,
   });
 
@@ -50,6 +53,7 @@ function parseArgs(argv) {
   const args = {
     check: false,
     branch: process.env.GITHUB_REF_NAME || "",
+    defaultPinOpenClaw: "",
     json: false,
     readmePath: defaultReadmePath,
     runUrl: process.env.CRABPOT_RUN_URL || "",
@@ -60,6 +64,11 @@ function parseArgs(argv) {
     const arg = argv[index];
     if (arg === "--check") {
       args.check = true;
+      continue;
+    }
+    if (arg === "--default-pin-openclaw") {
+      args.defaultPinOpenClaw = path.resolve(argv[index + 1]);
+      index += 1;
       continue;
     }
     if (arg === "--json") {
@@ -97,6 +106,28 @@ export async function resolveTrackMetadata() {
     resolveOpenClawTrack("development"),
   ]);
   return [latest, beta, development];
+}
+
+export async function resolveDefaultPinMetadata(openclawPath, options = {}) {
+  const pin = await readOpenClawPin(options.pinPath);
+  const pkg = JSON.parse(await readFile(path.join(openclawPath, "package.json"), "utf8"));
+  const checkoutSha = execFileSync("git", ["-C", openclawPath, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  if (checkoutSha !== pin.sha) {
+    throw new Error(`Default Track checkout ${checkoutSha} does not match configured pin ${pin.sha}`);
+  }
+  if (!pkg.version || typeof pkg.version !== "string") {
+    throw new Error("Default Track OpenClaw checkout has no string package version");
+  }
+  return {
+    branch: "main",
+    label: `${pin.repository}@${pin.sha.slice(0, 12)}`,
+    ref: pin.sha,
+    repository: pin.repository,
+    sha: pin.sha,
+    source: "github-default-pin",
+    track: "latest",
+    version: pkg.version,
+  };
 }
 
 export async function updateTrackMetadata({
@@ -158,11 +189,14 @@ function blockSuffix(suffix) {
 
 export function renderTrackMetadata(tracks, options = {}) {
   const selected = selectTrack(tracks, options);
+  const dashboardTarget = selected.source === "github-default-pin"
+    ? `${selected.repository}@${selected.sha.slice(0, 12)} + npm latest plugin artifacts`
+    : trackTargets[selected.track] ?? selected.label;
   return [
     `- **Source:** \`${selected.source}\``,
     `- **OpenClaw version:** \`${selected.version}\``,
     `- **OpenClaw SHA:** \`${selected.sha.slice(0, 12)}\``,
-    `- **Dashboard target:** \`${trackTargets[selected.track] ?? selected.label}\``,
+    `- **Dashboard target:** \`${dashboardTarget}\``,
     `- **Plugin artifacts:** \`${pluginArtifacts[selected.track] ?? "manifest package pins"}\``,
     `- **GitHub report run:** ${formatRunLink(options.runUrl)}`,
   ].join("\n");

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -51,6 +51,7 @@ test("default check workflow uploads policy and summary reports", async () => {
   assert.match(workflow, /node scripts\/run-static-suite\.mjs[\s\S]*--openclaw \.\/openclaw[\s\S]*--plugin-inspector-smoke/);
   assert.match(workflow, /node scripts\/check-ci-policy\.mjs/);
   assert.match(workflow, /node scripts\/write-ci-summary\.mjs/);
+  assert.match(workflow, /node scripts\/update-track-metadata\.mjs --default-pin-openclaw \.\/openclaw/);
   const dashboardBlock = workflow.slice(workflow.indexOf("  dashboard:"));
   assert.match(dashboardBlock, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
   assert.match(dashboardBlock, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs 3/);
@@ -127,14 +128,50 @@ test("track dashboard workflow refreshes branch dashboards by OpenClaw track", a
 test("default check workflow runs OS and container static lanes", async () => {
   const workflow = await readWorkflow(".github/workflows/check.yml");
 
-  assert.match(workflow, /name: Static checks \(\$\{\{ matrix\.os \}\}\)/);
+  assert.match(workflow, /name: Default Track \/ Static checks \(\$\{\{ matrix\.os \}\}\)/);
   assert.match(workflow, /os: \[ubuntu-latest, macos-15, windows-latest\]/);
   assert.match(workflow, /container-smoke:/);
   assert.match(workflow, /image: node:22-bookworm/);
+  assert.match(workflow, /node scripts\/openclaw-pin\.mjs --github-output/);
+  assert.doesNotMatch(workflow, /node scripts\/resolve-openclaw-track\.mjs --github-output/);
+  assert.doesNotMatch(workflow, /node scripts\/update-track-metadata\.mjs\n/);
   assert.match(workflow, /node scripts\/run-static-suite\.mjs[\s\S]*--openclaw \.\/openclaw[\s\S]*--plugin-inspector-smoke/);
   assert.match(workflow, /--plugin-track "\$\{plugin_track\}"/);
   assert.match(workflow, /--fixture-set openclaw-beta --plugin-track source-pack/);
-  assert.match(workflow, /crabpot-check-reports-\$\{\{ matrix\.os \}\}/);
+  assert.match(workflow, /crabpot-default-track-reports-\$\{\{ matrix\.os \}\}/);
+  assert.match(workflow, /name: Default Track \(pinned OpenClaw\)/);
+  assert.match(workflow, /needs: \[manifest, container-smoke, changed-fixture-plan, changed-isolated-fixture\]/);
+});
+
+test("HEAD canary is advisory, runs the Default Track suite on main, and uploads reports", async () => {
+  const workflow = await readWorkflow(".github/workflows/openclaw-head-canary.yml");
+
+  assert.match(workflow, /name: OpenClaw HEAD Canary \(Advisory\)/);
+  assert.match(workflow, /name: HEAD Canary \/ Resolve OpenClaw HEAD/);
+  assert.match(workflow, /sha: \$\{\{ steps\.openclaw-head\.outputs\.sha \}\}/);
+  assert.match(workflow, /name: HEAD Canary \(advisory, \$\{\{ matrix\.os \}\}\)/);
+  assert.match(workflow, /needs: resolve-head/);
+  assert.match(workflow, /continue-on-error: true/);
+  assert.match(workflow, /repository: openclaw\/openclaw\n\s+ref: main/);
+  assert.match(workflow, /repository: openclaw\/openclaw\n\s+ref: \$\{\{ needs\.resolve-head\.outputs\.sha \}\}/);
+  assert.match(workflow, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
+  assert.match(workflow, /Check npm latest metadata[\s\S]*continue-on-error: true[\s\S]*node scripts\/resolve-openclaw-track\.mjs --track latest --warn-missing-tag/);
+  assert.match(workflow, /Run Default Track suite against HEAD/);
+  assert.match(workflow, /--openclaw-track latest/);
+  assert.match(workflow, /--plugin-track latest/);
+  assert.match(workflow, /run_report\(\)[\s\S]*report_failed=1/);
+  assert.match(workflow, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs 3/);
+  assert.match(workflow, /exit "\$\{report_failed\}"/);
+  assert.match(workflow, /Upload HEAD canary reports/);
+  assert.match(workflow, /crabpot-openclaw-head-canary-\$\{\{ matrix\.os \}\}/);
+});
+
+test("scheduled Default Track pin age gate enforces the 14-day SLA", async () => {
+  const workflow = await readWorkflow(".github/workflows/openclaw-pin-age.yml");
+
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /name: Default Track pin age \(14-day SLA\)/);
+  assert.match(workflow, /node scripts\/openclaw-pin\.mjs --check-age --max-age-days 14/);
 });
 
 test("default check workflow resolves changed submodules into an isolated fixture matrix", async () => {
@@ -164,6 +201,8 @@ test("workflows use current action majors and dependency caches", async () => {
     await readWorkflow(".github/workflows/check.yml"),
     await readWorkflow(".github/workflows/openclaw-ref-compat.yml"),
     await readWorkflow(".github/workflows/dependabot-auto-merge.yml"),
+    await readWorkflow(".github/workflows/openclaw-head-canary.yml"),
+    await readWorkflow(".github/workflows/openclaw-pin-age.yml"),
     await readWorkflow(".github/workflows/track-dashboard.yml"),
   ].join("\n");
   const actionRefs = [

--- a/test/openclaw-pin.test.mjs
+++ b/test/openclaw-pin.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { pinAgeDays, pinOutputs, validatePin } from "../scripts/openclaw-pin.mjs";
+
+const pin = {
+  repository: "openclaw/openclaw",
+  sha: "e3eb1121adfb3eef87200d2964f01396e2b6acbc",
+  pinnedAt: "2026-07-18",
+};
+
+test("Default Track pin exposes immutable checkout outputs", () => {
+  validatePin(pin);
+  assert.deepEqual(pinOutputs(pin), {
+    label: "openclaw/openclaw@e3eb1121adfb (Default Track pin 2026-07-18)",
+    pinned_at: "2026-07-18",
+    ref: pin.sha,
+    repository: "openclaw/openclaw",
+    sha: pin.sha,
+    track: "latest",
+  });
+});
+
+test("pin age uses UTC dates and permits the 14th day", () => {
+  assert.equal(pinAgeDays(pin, new Date("2026-08-01T23:59:59Z")), 14);
+  assert.equal(pinAgeDays(pin, new Date("2026-08-02T00:00:00Z")), 15);
+  assert.throws(() => pinAgeDays(pin, new Date("2026-07-17T23:59:59Z")), /is in the future/);
+});
+
+test("Default Track pin rejects branch refs and invalid dates", () => {
+  assert.throws(() => validatePin({ ...pin, sha: "main" }), /40 lowercase hexadecimal/);
+  assert.throws(() => validatePin({ ...pin, pinnedAt: "2026-02-31" }), /valid YYYY-MM-DD/);
+});

--- a/test/track-metadata.test.mjs
+++ b/test/track-metadata.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 import { normalizeTrack } from "../scripts/resolve-openclaw-track.mjs";
-import { applyTrackMetadata, renderTrackMetadata } from "../scripts/update-track-metadata.mjs";
+import { applyTrackMetadata, renderTrackMetadata, resolveDefaultPinMetadata } from "../scripts/update-track-metadata.mjs";
 
 const tracks = [
   {
@@ -63,4 +67,48 @@ test("track metadata inserts before dashboard summary and replaces stale block",
   assert.doesNotMatch(replaced, /\ncontent\n/);
   assert.match(replaced, /new content/);
   assert.match(replaced, /<!-- crabpot-summary:start -->/);
+});
+
+test("pinned Default Track metadata names the immutable dashboard target", () => {
+  const markdown = renderTrackMetadata([
+    {
+      branch: "main",
+      label: "openclaw/openclaw@e3eb1121adfb",
+      ref: "e3eb1121adfb3eef87200d2964f01396e2b6acbc",
+      repository: "openclaw/openclaw",
+      sha: "e3eb1121adfb3eef87200d2964f01396e2b6acbc",
+      source: "github-default-pin",
+      track: "latest",
+      version: "2026.7.2",
+    },
+  ], { branch: "main" });
+
+  assert.match(markdown, /Source:\*\* `github-default-pin`/);
+  assert.match(markdown, /Dashboard target:\*\* `openclaw\/openclaw@e3eb1121adfb \+ npm latest plugin artifacts`/);
+});
+
+test("pinned metadata is derived from the exact local checkout", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "crabpot-pin-metadata-"));
+  try {
+    const openclawPath = path.join(root, "openclaw");
+    const pinPath = path.join(root, "pin.json");
+    execFileSync("git", ["init", "-q", openclawPath]);
+    await writeFile(path.join(openclawPath, "package.json"), '{"version":"2026.7.2"}\n', "utf8");
+    execFileSync("git", ["-C", openclawPath, "add", "package.json"]);
+    execFileSync("git", [
+      "-C", openclawPath,
+      "-c", "user.name=Crabpot Test",
+      "-c", "user.email=crabpot@example.invalid",
+      "commit", "-q", "-m", "fixture",
+    ]);
+    const sha = execFileSync("git", ["-C", openclawPath, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    await writeFile(pinPath, `${JSON.stringify({ repository: "openclaw/openclaw", sha, pinnedAt: "2026-07-18" })}\n`, "utf8");
+
+    const metadata = await resolveDefaultPinMetadata(openclawPath, { pinPath });
+    assert.equal(metadata.sha, sha);
+    assert.equal(metadata.version, "2026.7.2");
+    assert.equal(metadata.source, "github-default-pin");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

- pin required Default Track CI to OpenClaw `e3eb1121adfb3eef87200d2964f01396e2b6acbc`
- add a non-blocking, artifact-producing OpenClaw HEAD canary using one resolved SHA across platforms
- enforce a scheduled 14-day pin-age SLA and document one-command promotion
- tolerate missing npm-latest GitHub tags as canary warnings while deriving required dashboard metadata from the pin

## Proof

- `node --test test/openclaw-pin.test.mjs test/track-metadata.test.mjs test/ci-workflows.test.mjs` (24/24)
- `actionlint`
- `git diff --check`
- autoreview clean: no accepted/actionable findings
