### PR TITLE
fix(ci): run pinned dashboard after skipped matrix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -265,7 +265,7 @@ jobs:
   dashboard:
     runs-on: ubuntu-latest
     needs: [default-track]
-    if: ${{ github.event_name != 'pull_request' && github.actor != 'github-actions[bot]' && needs.default-track.result == 'success' }}
+    if: ${{ always() && github.event_name != 'pull_request' && github.actor != 'github-actions[bot]' && needs.default-track.result == 'success' }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -265,7 +265,7 @@ jobs:
   dashboard:
     runs-on: ubuntu-latest
     needs: [default-track]
-    if: ${{ always() && github.event_name != 'pull_request' && github.actor != 'github-actions[bot]' && needs.default-track.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.actor != 'github-actions[bot]' && needs.default-track.result == 'success' }}
     permissions:
       contents: write
     steps:

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -53,7 +53,7 @@ test("default check workflow uploads policy and summary reports", async () => {
   assert.match(workflow, /node scripts\/write-ci-summary\.mjs/);
   assert.match(workflow, /node scripts\/update-track-metadata\.mjs --default-pin-openclaw \.\/openclaw/);
   const dashboardBlock = workflow.slice(workflow.indexOf("  dashboard:"));
-  assert.match(dashboardBlock, /if: \$\{\{ always\(\) && github\.event_name != 'pull_request'/);
+  assert.match(dashboardBlock, /if: \$\{\{ !cancelled\(\) && github\.event_name != 'pull_request'/);
   assert.match(dashboardBlock, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
   assert.match(dashboardBlock, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs 3/);
   assert.match(workflow, /--baseline-data \.crabpot\/baseline\/main-dashboard-data\.json/);

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -53,6 +53,7 @@ test("default check workflow uploads policy and summary reports", async () => {
   assert.match(workflow, /node scripts\/write-ci-summary\.mjs/);
   assert.match(workflow, /node scripts\/update-track-metadata\.mjs --default-pin-openclaw \.\/openclaw/);
   const dashboardBlock = workflow.slice(workflow.indexOf("  dashboard:"));
+  assert.match(dashboardBlock, /if: \$\{\{ always\(\) && github\.event_name != 'pull_request'/);
   assert.match(dashboardBlock, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
   assert.match(dashboardBlock, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs 3/);
   assert.match(workflow, /--baseline-data \.crabpot\/baseline\/main-dashboard-data\.json/);


### PR DESCRIPTION
## Summary

- preserve the dashboard job's `always()` dependency guard
- ensure pinned dashboard metadata runs after the optional changed-fixture matrix is skipped
- add a workflow regression assertion

## Proof

- `node --test test/ci-workflows.test.mjs` (16/16)
- `actionlint`
- autoreview clean
