### PR TITLE
chore: pin plugin-inspector 0.3.19 source

### DIFF
--- a/scripts/npm-pack-result.mjs
+++ b/scripts/npm-pack-result.mjs
@@ -1,0 +1,16 @@
+export function parseNpmPackResult(output) {
+  const parsed = JSON.parse(output);
+  if (Array.isArray(parsed)) {
+    return parsed[0];
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return undefined;
+  }
+  const results = Object.values(parsed);
+  return results.length === 1 ? results[0] : undefined;
+}
+
+export function parseNpmViewResult(output) {
+  const parsed = JSON.parse(output);
+  return Array.isArray(parsed) ? parsed[0] : parsed;
+}

--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
-export const pluginInspectorRef = "4a30347d6b4b04d823da81e865e22c3f9ff770c9";
+export const pluginInspectorRef = "d9b70fd41756d63b385411e5fcc4be6da727a21c";
 export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.18";
 
 export async function loadPluginInspector() {

--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
-export const pluginInspectorRef = "d9b70fd41756d63b385411e5fcc4be6da727a21c";
+export const pluginInspectorRef = "0d97f0659e944598f783867b43e7971903958b9f";
 export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.18";
 
 export async function loadPluginInspector() {

--- a/scripts/sync-fixtures.mjs
+++ b/scripts/sync-fixtures.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fixtureSourceRoot, readConfiguredManifest, repoRoot } from "./manifest-lib.mjs";
+import { parseNpmPackResult, parseNpmViewResult } from "./npm-pack-result.mjs";
 import { writePackageAvailabilityReport } from "./package-availability.mjs";
 
 const openclawSourceRepo = "https://github.com/openclaw/openclaw.git";
@@ -122,7 +123,7 @@ async function materializeNpmFixture(fixture, target) {
       }
       return;
     }
-    const packed = JSON.parse(pack.stdout)[0];
+    const packed = parseNpmPackResult(pack.stdout);
     if (!packed?.filename) {
       throw new Error(`npm pack ${spec} did not return a tarball filename`);
     }
@@ -171,7 +172,7 @@ async function materializeSourcePackFixture(fixture, target) {
       const detail = pack.error ? `: ${pack.error.message}` : "";
       throw new Error(`npm pack ${sourceDir} failed with ${pack.status}${detail}`);
     }
-    const packed = JSON.parse(pack.stdout)[0];
+    const packed = parseNpmPackResult(pack.stdout);
     if (!packed?.filename) {
       throw new Error(`npm pack ${sourceDir} did not return a tarball filename`);
     }
@@ -302,7 +303,7 @@ async function npmDistTag(name, tag) {
     const detail = spawnFailureDetail(result);
     throw new Error(`${name}: npm dist-tag ${tag} could not be resolved${detail}`);
   }
-  const tags = JSON.parse(result.stdout || "{}");
+  const tags = parseNpmViewResult(result.stdout || "{}") ?? {};
   const version = tags[tag];
   if (typeof version !== "string" || !/^\d+\.\d+\.\d+/.test(version)) {
     throw new Error(`${name}: npm dist-tag ${tag} resolved to invalid version ${JSON.stringify(version)}`);
@@ -330,7 +331,7 @@ async function npmPackageGitHead(name, version) {
   if (result.status !== 0 || !result.stdout.trim()) {
     return "";
   }
-  const gitHead = JSON.parse(result.stdout);
+  const gitHead = parseNpmViewResult(result.stdout);
   return /^[0-9a-f]{40}$/i.test(gitHead ?? "") ? gitHead : "";
 }
 

--- a/test/npm-pack-result.test.mjs
+++ b/test/npm-pack-result.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseNpmPackResult, parseNpmViewResult } from "../scripts/npm-pack-result.mjs";
+
+test("npm pack results accept array and keyed npm JSON shapes", () => {
+  const packed = { filename: "fixture-1.0.0.tgz", version: "1.0.0" };
+
+  assert.deepEqual(parseNpmPackResult(JSON.stringify([packed])), packed);
+  assert.deepEqual(parseNpmPackResult(JSON.stringify({ "@fixture/plugin": packed })), packed);
+});
+
+test("npm pack results reject empty or ambiguous keyed output", () => {
+  assert.equal(parseNpmPackResult("{}"), undefined);
+  assert.equal(
+    parseNpmPackResult(
+      JSON.stringify({
+        first: { filename: "first.tgz" },
+        second: { filename: "second.tgz" },
+      }),
+    ),
+    undefined,
+  );
+});
+
+test("npm view results accept direct and npm 11 array JSON shapes", () => {
+  const tags = { latest: "1.2.3", beta: "1.3.0-beta.1" };
+
+  assert.deepEqual(parseNpmViewResult(JSON.stringify(tags)), tags);
+  assert.deepEqual(parseNpmViewResult(JSON.stringify([tags])), tags);
+  assert.equal(parseNpmViewResult(JSON.stringify(["a".repeat(40)])), "a".repeat(40));
+});


### PR DESCRIPTION
## Summary

- pin Crabpot source-mode smoke to the exact plugin-inspector v0.3.19 release commit
- accept npm 11 array/keyed JSON shapes from registry `view` and `pack` commands
- keep the existing manifest-contract regression expectation that proves the restored finding

## Proof

- full pinned 19-step static suite (60 fixtures, 177/177 tests, generated-surface PASS, 400 issues, 275 probes, CI policy PASS)
- `CRABPOT_PLUGIN_INSPECTOR_CLI=source npm run plugin-inspector:smoke` (PASS; 60 fixtures)
- plugin-inspector Crabpot follow-through checklist passes the exact source ref and public API migration checks
- autoreview clean with no accepted or actionable findings
