### PR TITLE
chore: pin plugin-inspector 0.3.20

### DIFF
--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -4,8 +4,8 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
-export const pluginInspectorRef = "0d97f0659e944598f783867b43e7971903958b9f";
-export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.19";
+export const pluginInspectorRef = "718b5aa8a4c8cf54a5cf6c4848785263c37e5d70";
+export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.20";
 
 export async function loadPluginInspector() {
   const publicApi = await import(pathToFileURL(resolvePluginInspectorSourcePath()).href);


### PR DESCRIPTION
## Summary
- pin Plugin Inspector source mode to release commit `718b5aa8a4c8cf54a5cf6c4848785263c37e5d70`
- pin package mode to `@openclaw/plugin-inspector@0.3.20`

## Validation
- `node --test test/plugin-inspector-source.test.mjs` (3 tests)
- source-mode `npm run plugin-inspector:smoke` (command succeeded; 37 existing dashboard breakages)
- package-mode `npm run plugin-inspector:smoke` (same 37 existing dashboard breakages)
- `npm run release:crabpot -- --published` from Plugin Inspector v0.3.20

Release: https://github.com/openclaw/plugin-inspector/releases/tag/v0.3.20
