### PR TITLE
fix(ci): keep development dashboard compatible with OpenClaw main

### DIFF
--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -1,10 +1,10 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
-export const pluginInspectorRef = "0d97f0659e944598f783867b43e7971903958b9f";
+export const pluginInspectorRef = "c61aeb8890bdf367dfee8dfda5fc7123c4e6737b";
 export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.19";
 
 export async function loadPluginInspector() {
@@ -73,27 +73,38 @@ function ensurePinnedInspectorCheckout() {
   const checkoutParent = path.join(repoRoot, ".crabpot", "plugin-inspector");
   const checkoutDir = path.join(checkoutParent, pluginInspectorRef);
   const sourcePath = path.join(checkoutDir, "src", "index.js");
+  const installMarker = path.join(checkoutDir, "node_modules", ".crabpot-install-ready");
 
-  if (existsSync(sourcePath) && readGitHead(checkoutDir) === pluginInspectorRef) {
+  if (isPinnedCheckoutReady(checkoutDir)) {
     return checkoutDir;
   }
 
   mkdirSync(checkoutParent, { recursive: true });
   withCheckoutLock(checkoutParent, () => {
-    if (existsSync(sourcePath) && readGitHead(checkoutDir) === pluginInspectorRef) {
+    if (isPinnedCheckoutReady(checkoutDir)) {
       return;
     }
 
-    rmSync(checkoutDir, { force: true, recursive: true });
-    run("git", ["init", checkoutDir]);
-    run("git", ["-C", checkoutDir, "fetch", "--depth=1", "https://github.com/openclaw/plugin-inspector.git", pluginInspectorRef]);
-    run("git", ["-C", checkoutDir, "checkout", "--detach", "FETCH_HEAD"]);
+    if (!existsSync(sourcePath) || readGitHead(checkoutDir) !== pluginInspectorRef) {
+      rmSync(checkoutDir, { force: true, recursive: true });
+      run("git", ["init", checkoutDir]);
+      run("git", ["-C", checkoutDir, "fetch", "--depth=1", "https://github.com/openclaw/plugin-inspector.git", pluginInspectorRef]);
+      run("git", ["-C", checkoutDir, "checkout", "--detach", "FETCH_HEAD"]);
+    }
+    run(npmCommand(), ["ci", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"], checkoutDir);
+    writeFileSync(installMarker, `${pluginInspectorRef}\n`, "utf8");
   });
 
-  if (readGitHead(checkoutDir) !== pluginInspectorRef) {
-    throw new Error(`plugin-inspector checkout did not resolve to ${pluginInspectorRef}`);
+  if (!isPinnedCheckoutReady(checkoutDir)) {
+    throw new Error(`plugin-inspector checkout did not prepare ${pluginInspectorRef}`);
   }
   return checkoutDir;
+}
+
+export function isPinnedCheckoutReady(checkoutDir, expectedRef = pluginInspectorRef) {
+  const sourcePath = path.join(checkoutDir, "src", "index.js");
+  const installMarker = path.join(checkoutDir, "node_modules", ".crabpot-install-ready");
+  return existsSync(sourcePath) && readGitHead(checkoutDir) === expectedRef && existsSync(installMarker);
 }
 
 function withCheckoutLock(checkoutParent, callback) {
@@ -149,10 +160,11 @@ function readGitHead(checkoutDir) {
   return result.stdout.trim();
 }
 
-function run(command, commandArgs) {
+function run(command, commandArgs, cwd = repoRoot) {
   const result = spawnSync(command, commandArgs, {
-    cwd: repoRoot,
+    cwd,
     encoding: "utf8",
+    shell: process.platform === "win32" && command === npmCommand(),
     stdio: "pipe",
   });
   if (result.error) {

--- a/test/plugin-inspector-source.test.mjs
+++ b/test/plugin-inspector-source.test.mjs
@@ -1,11 +1,47 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 import {
+  isPinnedCheckoutReady,
   pluginInspectorPackage,
+  pluginInspectorRef,
   resolvePluginInspectorCliInvocation,
   resolvePluginInspectorCliPath,
 } from "../scripts/plugin-inspector-source.mjs";
+
+test("plugin inspector source pin requires an exact prepared checkout", (t) => {
+  assert.equal(pluginInspectorRef, "c61aeb8890bdf367dfee8dfda5fc7123c4e6737b");
+
+  const checkoutDir = mkdtempSync(path.join(os.tmpdir(), "crabpot-plugin-inspector-"));
+  t.after(() => rmSync(checkoutDir, { force: true, recursive: true }));
+  const sourcePath = path.join(checkoutDir, "src", "index.js");
+  const installMarker = path.join(checkoutDir, "node_modules", ".crabpot-install-ready");
+  mkdirSync(path.dirname(sourcePath), { recursive: true });
+  writeFileSync(sourcePath, "export {};\n", "utf8");
+  runGit(checkoutDir, ["init"]);
+  runGit(checkoutDir, ["add", "src/index.js"]);
+  runGit(checkoutDir, [
+    "-c",
+    "user.name=Crabpot Test",
+    "-c",
+    "user.email=crabpot@example.invalid",
+    "commit",
+    "-m",
+    "test fixture",
+  ]);
+  const fixtureRef = runGit(checkoutDir, ["rev-parse", "HEAD"]).stdout.trim();
+
+  assert.equal(isPinnedCheckoutReady(checkoutDir, fixtureRef), false);
+  mkdirSync(path.dirname(installMarker), { recursive: true });
+  writeFileSync(installMarker, `${fixtureRef}\n`, "utf8");
+  assert.equal(isPinnedCheckoutReady(checkoutDir, fixtureRef), true);
+  assert.equal(isPinnedCheckoutReady(checkoutDir, pluginInspectorRef), false);
+  rmSync(installMarker);
+  assert.equal(isPinnedCheckoutReady(checkoutDir, fixtureRef), false);
+});
 
 test("plugin inspector smoke defaults to the published npm package", () => {
   withEnv({}, () => {
@@ -41,13 +77,24 @@ test("plugin inspector smoke can run local source or an explicit binary", () => 
 });
 
 test("plugin inspector smoke uses full default findings output", () => {
+  const sourceScript = readFileSync(new URL("../scripts/plugin-inspector-source.mjs", import.meta.url), "utf8");
   const smokeScript = readFileSync(new URL("../scripts/run-plugin-inspector-smoke.mjs", import.meta.url), "utf8");
 
+  assert.match(
+    sourceScript,
+    /run\(npmCommand\(\), \["ci", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"\], checkoutDir\)/,
+  );
   assert.doesNotMatch(smokeScript, /--include-inspector-gaps/);
   assert.doesNotMatch(smokeScript, /--author-facing/);
   assert.doesNotMatch(smokeScript, /const command =/);
   assert.match(smokeScript, /"report", "--config", configPath, "--out", outDir/);
 });
+
+function runGit(cwd, args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return result;
+}
 
 function withEnv(values, callback) {
   const keys = ["CRABPOT_PLUGIN_INSPECTOR_BIN", "CRABPOT_PLUGIN_INSPECTOR_CLI"];


### PR DESCRIPTION
Related: #273

## What Problem This Solves

Fixes an issue where the development Track Dashboard crashed while probing the Codex plugin against current OpenClaw `main`.

## Why This Change Was Made

Pins Crabpot's source-mode plugin-inspector checkout to the owner fix that preserves OpenClaw record helper contracts in generated SDK mocks. Pinned source checkouts now install locked production dependencies once under the existing checkout lock, so source releases remain usable when their runtime dependency set changes. The published package remains on `0.3.19`; publishing a fixed package is a separate release operation.

## User Impact

Maintainers can refresh the development dashboard against moving OpenClaw `main` without the synthetic probe recursing through primitive schema values.

## Evidence

- Failure reproduced twice in Track Dashboard run `30824260538`.
- Owner fix: `openclaw/plugin-inspector@c61aeb8890bdf367dfee8dfda5fc7123c4e6737b`.
- Owner exact-head Check and CodeQL workflows are green.
- plugin-inspector Node 22 suite: 235/235 passing.
- `node --test test/plugin-inspector-source.test.mjs`: 4/4 passing, including exact-ref and install-marker readiness coverage.
- The exact changed-fixture resolver command that failed in CI now passes with an empty fixture matrix.
- A second source-checkout test run reuses the prepared checkout without reinstalling dependencies.
- Autoreview: no P0 findings.

## Fixture Impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [x] Changes contract or smoke logic
- [ ] Docs only

## Fixture Verification

- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] Strict fixture smoke, if submodules were materialized

## Notes

The full dashboard and three-platform HEAD canary are the authoritative integration proof because they materialize the current OpenClaw checkout and plugin fixtures in clean hosted runners.
