### PR TITLE
fix(ci): record the tested dashboard revision

### DIFF
--- a/.github/workflows/track-dashboard.yml
+++ b/.github/workflows/track-dashboard.yml
@@ -168,7 +168,7 @@ jobs:
           fi
           node scripts/check-ci-policy.mjs
           node scripts/write-ci-summary.mjs --mode "track:${{ matrix.track }}" --openclaw-label "${{ steps.openclaw-track.outputs.label }}"
-          node scripts/update-track-metadata.mjs --track "${{ matrix.track }}"
+          node scripts/update-track-metadata.mjs --track "${{ matrix.track }}" --openclaw ./openclaw
           baseline_args=()
           if [ -f .crabpot/baseline/main-dashboard-data.json ]; then
             baseline_args=(--baseline-data .crabpot/baseline/main-dashboard-data.json)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Refreshed plugin fixtures and restored real OpenClaw lifecycle profiling against current diagnostics APIs.
 - Split CI into a required pinned OpenClaw Default Track, an advisory artifact-producing HEAD canary, and a 14-day pin-promotion SLA.
 - Kept each track dashboard independent from unrelated OpenClaw release metadata failures.
+- Recorded dashboard metadata from the exact OpenClaw checkout exercised by the run.
 
 ## 0.2.1 - 2026-07-06
 

--- a/scripts/update-track-metadata.mjs
+++ b/scripts/update-track-metadata.mjs
@@ -5,7 +5,11 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 import { readOpenClawPin } from "./openclaw-pin.mjs";
-import { normalizeTrack, resolveOpenClawTrack } from "./resolve-openclaw-track.mjs";
+import {
+  normalizeTrack,
+  openclawRepository,
+  resolveOpenClawTrack,
+} from "./resolve-openclaw-track.mjs";
 
 export const trackMetadataStart = "<!-- crabpot-tracks:start -->";
 export const trackMetadataEnd = "<!-- crabpot-tracks:end -->";
@@ -31,7 +35,9 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   const tracks = args.defaultPinOpenClaw
     ? [await resolveDefaultPinMetadata(args.defaultPinOpenClaw)]
-    : await resolveTrackMetadata(args.track, args.branch);
+    : args.openclaw
+      ? [await resolveCheckoutMetadata(args.openclaw, args.track, args.branch)]
+      : await resolveTrackMetadata(args.track, args.branch);
   const changed = await updateTrackMetadata({
     branch: args.branch,
     check: args.check,
@@ -55,6 +61,7 @@ function parseArgs(argv) {
     branch: process.env.GITHUB_REF_NAME || "",
     defaultPinOpenClaw: "",
     json: false,
+    openclaw: "",
     readmePath: defaultReadmePath,
     runUrl: process.env.CRABPOT_RUN_URL || "",
     track: "auto",
@@ -73,6 +80,11 @@ function parseArgs(argv) {
     }
     if (arg === "--json") {
       args.json = true;
+      continue;
+    }
+    if (arg === "--openclaw") {
+      args.openclaw = path.resolve(argv[index + 1]);
+      index += 1;
       continue;
     }
     if (arg === "--readme") {
@@ -103,25 +115,43 @@ export async function resolveTrackMetadata(track = "auto", branch = "", resolve 
   return [await resolve(normalizeTrack(track, branch))];
 }
 
+export async function resolveCheckoutMetadata(openclawPath, track = "auto", branch = "") {
+  const normalized = normalizeTrack(track, branch);
+  const pkg = JSON.parse(await readFile(path.join(openclawPath, "package.json"), "utf8"));
+  const sha = execFileSync("git", ["-C", openclawPath, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  if (!pkg.version || typeof pkg.version !== "string") {
+    throw new Error("OpenClaw checkout has no string package version");
+  }
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(`OpenClaw checkout has invalid revision ${sha}`);
+  }
+  const source = normalized === "development" ? "github-main" : `npm-${normalized}`;
+  return {
+    branch: normalized === "latest" ? "main" : `crab-${normalized}`,
+    label: normalized === "development"
+      ? `${openclawRepository}@main (${pkg.version}, ${sha.slice(0, 12)})`
+      : `openclaw@${normalized} (${pkg.version}, ${sha.slice(0, 12)})`,
+    ref: normalized === "development" ? sha : `v${pkg.version}`,
+    repository: openclawRepository,
+    sha,
+    source,
+    track: normalized,
+    version: pkg.version,
+  };
+}
+
 export async function resolveDefaultPinMetadata(openclawPath, options = {}) {
   const pin = await readOpenClawPin(options.pinPath);
-  const pkg = JSON.parse(await readFile(path.join(openclawPath, "package.json"), "utf8"));
-  const checkoutSha = execFileSync("git", ["-C", openclawPath, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
-  if (checkoutSha !== pin.sha) {
-    throw new Error(`Default Track checkout ${checkoutSha} does not match configured pin ${pin.sha}`);
-  }
-  if (!pkg.version || typeof pkg.version !== "string") {
-    throw new Error("Default Track OpenClaw checkout has no string package version");
+  const checkout = await resolveCheckoutMetadata(openclawPath, "latest");
+  if (checkout.sha !== pin.sha) {
+    throw new Error(`Default Track checkout ${checkout.sha} does not match configured pin ${pin.sha}`);
   }
   return {
-    branch: "main",
+    ...checkout,
     label: `${pin.repository}@${pin.sha.slice(0, 12)}`,
     ref: pin.sha,
     repository: pin.repository,
-    sha: pin.sha,
     source: "github-default-pin",
-    track: "latest",
-    version: pkg.version,
   };
 }
 

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -127,7 +127,10 @@ test("track dashboard workflow refreshes branch dashboards by OpenClaw track", a
   assert.match(workflow, /run_profile_step 240 "OpenClaw runtime profile failed or timed out; falling back to fixture-only runtime profile" node scripts\/profile-contract-runtime\.mjs --openclaw \.\/openclaw --runs 3/);
   assert.match(workflow, /run_profile_step 120 "fixture-only runtime profile failed or timed out; continuing without refreshed runtime metrics" node scripts\/profile-contract-runtime\.mjs --runs 3 \|\| true/);
   assert.match(workflow, /if \[ -f reports\/crabpot-runtime-profile\.json \]; then[\s\S]*node scripts\/compare-runtime-profile\.mjs[\s\S]*Runtime profile was not refreshed; skipping runtime profile diff/);
-  assert.match(workflow, /node scripts\/update-track-metadata\.mjs --track "\$\{\{ matrix\.track \}\}"/);
+  assert.match(
+    workflow,
+    /node scripts\/update-track-metadata\.mjs --track "\$\{\{ matrix\.track \}\}" --openclaw \.\/openclaw/,
+  );
   assert.match(workflow, /origin\/main:reports\/crabpot-dashboard-data\.json/);
   assert.match(workflow, /baseline_args=\(\)/);
   assert.match(workflow, /node scripts\/update-readme-summary\.mjs "\$\{baseline_args\[@\]\}"/);

--- a/test/track-metadata.test.mjs
+++ b/test/track-metadata.test.mjs
@@ -8,6 +8,7 @@ import { normalizeTrack } from "../scripts/resolve-openclaw-track.mjs";
 import {
   applyTrackMetadata,
   renderTrackMetadata,
+  resolveCheckoutMetadata,
   resolveDefaultPinMetadata,
   resolveTrackMetadata,
 } from "../scripts/update-track-metadata.mjs";
@@ -110,6 +111,31 @@ test("pinned Default Track metadata names the immutable dashboard target", () =>
 
   assert.match(markdown, /Source:\*\* `github-default-pin`/);
   assert.match(markdown, /Dashboard target:\*\* `openclaw\/openclaw@e3eb1121adfb \+ npm latest plugin artifacts`/);
+});
+
+test("tested track metadata is derived from the exact local checkout", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "crabpot-track-metadata-"));
+  try {
+    const openclawPath = path.join(root, "openclaw");
+    execFileSync("git", ["init", "-q", openclawPath]);
+    await writeFile(path.join(openclawPath, "package.json"), '{"version":"2026.7.2"}\n', "utf8");
+    execFileSync("git", ["-C", openclawPath, "add", "package.json"]);
+    execFileSync("git", [
+      "-C", openclawPath,
+      "-c", "user.name=Crabpot Test",
+      "-c", "user.email=crabpot@example.invalid",
+      "commit", "-q", "-m", "fixture",
+    ]);
+    const sha = execFileSync("git", ["-C", openclawPath, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+
+    const metadata = await resolveCheckoutMetadata(openclawPath, "development");
+    assert.equal(metadata.sha, sha);
+    assert.equal(metadata.version, "2026.7.2");
+    assert.equal(metadata.source, "github-main");
+    assert.equal(metadata.label, `openclaw/openclaw@main (2026.7.2, ${sha.slice(0, 12)})`);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("pinned metadata is derived from the exact local checkout", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a development dashboard run could publish a newer OpenClaw SHA than the checkout it actually tested when `openclaw/openclaw` main advanced during the run.

The observed run resolved and checked out `5a65c96fc708`, but its published `crab-development` README named `94410b00d032`.

## Why This Change Was Made

Dashboard metadata now reads the version and Git revision from the exact local OpenClaw checkout used by the test run. The same checkout-owned resolver also backs immutable Default Track metadata, keeping one canonical producer for tested revision facts.

## User Impact

Operators can trust the dashboard's OpenClaw version and SHA to identify the code exercised by that report.

## Evidence

- Before: Track Dashboard run 30842793106 checked out `5a65c96fc708` and published `94410b00d032`.
- `node --test test/track-metadata.test.mjs test/ci-workflows.test.mjs`: 24 passed, 0 failed.
- `git diff --check`: passed.
- Script syntax checks: passed.
- Current main Check 30842780723: passed.
- Current main HEAD Canary 30842781760: passed.
- Full raw test invocation without fixture materialization: 179 passed, 10 failed because all 30 plugin submodules are intentionally uninitialized in the fresh worktree. The changed tests pass independently; CI materializes those fixtures.
- Structured autoreview exceeded its documented 30-minute ceiling and was stopped without a result. Manual final diff review found no blocking issue.

Production delta: +44/-14 non-test lines (+30 net). The growth establishes the tested checkout as the authoritative metadata owner and reuses that path for the existing pinned checkout flow.

## Fixture Impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [ ] Changes contract or smoke logic
- [ ] Docs only

## Fixture Verification

- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] Strict fixture smoke, if submodules were materialized

## Notes

No fixture definitions, submodule pins, plugin contracts, or runtime probes changed.
