### PR TITLE
fix(ci): promote the verified OpenClaw default pin

### DIFF
--- a/.github/openclaw-default-track.json
+++ b/.github/openclaw-default-track.json
@@ -1,5 +1,5 @@
 {
   "repository": "openclaw/openclaw",
-  "sha": "e3eb1121adfb3eef87200d2964f01396e2b6acbc",
-  "pinnedAt": "2026-07-18"
+  "sha": "7ae6a950f6b77f8695aa6c491a4506470e723d4e",
+  "pinnedAt": "2026-08-04"
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Reporting Data
 
-`main` follows the latest published npm package and npm `latest` plugin artifacts, with bundled OpenClaw fixtures source-packed from the matching checkout. `crab-beta` follows beta npm dist-tags for externalized packages and source-packs bundled fixtures. `crab-development` checks `openclaw/openclaw` main against source-packed official plugin artifacts from that same OpenClaw checkout.
+`main` follows a promoted green OpenClaw source pin plus npm `latest` plugin artifacts, with bundled fixtures source-packed from that pinned checkout. `crab-beta` follows beta npm dist-tags for externalized packages and source-packs bundled fixtures. `crab-development` checks `openclaw/openclaw` main against source-packed official plugin artifacts from that same OpenClaw checkout.
 - **Last dashboard update:** Aug 03, 2026, 20:08 UTC
 <!-- crabpot-tracks:start -->
 - **Source:** `github-default-pin`

--- a/scripts/update-readme-summary.mjs
+++ b/scripts/update-readme-summary.mjs
@@ -379,7 +379,7 @@ function renderReadmeFrame(summary) {
     "",
     "## Reporting Data",
     "",
-    "`main` follows the latest published npm package and npm `latest` plugin artifacts, with bundled OpenClaw fixtures source-packed from the matching checkout. `crab-beta` follows beta npm dist-tags for externalized packages and source-packs bundled fixtures. `crab-development` checks `openclaw/openclaw` main against source-packed official plugin artifacts from that same OpenClaw checkout.",
+    "`main` follows a promoted green OpenClaw source pin plus npm `latest` plugin artifacts, with bundled fixtures source-packed from that pinned checkout. `crab-beta` follows beta npm dist-tags for externalized packages and source-packs bundled fixtures. `crab-development` checks `openclaw/openclaw` main against source-packed official plugin artifacts from that same OpenClaw checkout.",
     `- **Last dashboard update:** ${summary.generatedAtLabel ?? formatTimestamp(summary.generatedAt)}`,
   ].join("\n");
 }

--- a/test/readme-summary.test.mjs
+++ b/test/readme-summary.test.mjs
@@ -420,6 +420,7 @@ test("readme frame follows compact reporting design and preserves dynamic blocks
   assert.match(framed, /^# 🦀 crabpot/u);
   assert.match(framed, /\*\*Goto: \[Latest Published\]/);
   assert.match(framed, /## Reporting Data/);
+  assert.match(framed, /`main` follows a promoted green OpenClaw source pin plus npm `latest` plugin artifacts/);
   assert.match(framed, /- \*\*Last dashboard update:\*\* Apr 26, 2026, 01:31 UTC/);
   assert.match(framed, /- \*\*Source:\*\* `npm-latest`/);
   assert.match(framed, /## Dashboard/);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Crabpot's scheduled pin-age SLA failed after the Default Track OpenClaw source pin exceeded 14 days, despite a newer fully green canary being available.

## Why This Change Was Made

Promotes the Default Track to the exact OpenClaw `2026.7.2` source SHA `7ae6a950f6b77f8695aa6c491a4506470e723d4e`, which passed the complete Crabpot canary matrix. It also corrects the generated README contract: `main` uses a deliberately promoted green OpenClaw source pin together with npm `latest` plugin artifacts.

No release, tag, package-version, changelog, fixture manifest, submodule, or smoke-contract change is included.

## User Impact

Operators regain a current, verified Default Track pin and accurate documentation of how Crabpot selects OpenClaw and plugin inputs.

## Evidence

- Fully green source-pin canary across Ubuntu, macOS, Windows, Default Track, and report jobs: https://github.com/openclaw/crabpot/actions/runs/30847492829
- `node --test test/readme-summary.test.mjs`: 7 passed, 0 failed.
- `git diff --check` passes for commit `4246f4d268c52b396da0fb7b04b41016d7fde75b`.
- Exact-head PR CI is required before merge.

Production delta: 4 additions, 4 deletions across workflow metadata and generated documentation source; test delta: 1 addition. Production code is net-neutral.

## Fixture Impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [ ] Changes contract or smoke logic
- [ ] Docs only

## Fixture Verification

- [x] `node --test test/readme-summary.test.mjs`
- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] Strict fixture smoke, if submodules were materialized

## Notes

The pin date is `2026-08-04` UTC. No credentials or live external-service checks are needed for this change.