### PR TITLE
fix: follow externalized QQbot fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.2 - Unreleased
 
+- Followed OpenClaw's externalized QQ Bot package and made moved source-pack fixtures report nearby package paths.
 - Refreshed plugin fixtures and restored real OpenClaw lifecycle profiling against current diagnostics APIs.
 - Split CI into a required pinned OpenClaw Default Track, an advisory artifact-producing HEAD canary, and a 14-day pin-promotion SLA.
 - Kept each track dashboard independent from unrelated OpenClaw release metadata failures.

--- a/crabpot.config.json
+++ b/crabpot.config.json
@@ -1058,40 +1058,30 @@
       "id": "openclaw-qqbot",
       "name": "OpenClaw QQ Bot channel plugin",
       "package": {
-        "name": "@openclaw/qqbot",
-        "tag": "beta"
+        "name": "@tencent-connect/openclaw-qqbot",
+        "version": "2.0.1"
       },
       "source": {
-        "repo": "https://github.com/openclaw/openclaw.git",
-        "path": "extensions/qqbot",
-        "ref": "5e63b365d4d3e62ef600b783fad7c5043b6f4738"
+        "repo": "https://github.com/tencent-connect/openclaw-qqbot.git",
+        "path": ".",
+        "ref": "88dee0b0e493469dc8c1684a5beafcbc66aa5bda"
       },
       "path": "plugins/openclaw-qqbot",
       "priority": "medium",
       "seams": [
         "channel",
-        "command",
         "tool",
         "media",
+        "proactive-messaging",
         "npm-artifact"
       ],
       "expect": {
         "registrations": [
-          "registerCommand",
+          "registerChannel",
           "registerTool"
         ]
       },
-      "execution": {
-        "blockedFailures": [
-          {
-            "id": "openclaw-qqbot-command-channel-config-runtime",
-            "seam": "registerCommand",
-            "errorIncludes": "reading 'channels'",
-            "reason": "captured QQ Bot command probe requires host channel configuration"
-          }
-        ]
-      },
-      "why": "Official OpenClaw QQ Bot npm package covering command/tool registration, channel manifest metadata, media-capable messaging, and monorepo source mapping without replacing the external QQBot fixture."
+      "why": "Official externalized QQ Bot npm package covering channel/tool registration, media-capable messaging, proactive delivery, and OpenClaw catalog compatibility without replacing the repository fixture."
     },
     {
       "id": "whatsapp",

--- a/plugins/openclaw-qqbot/package-lock.json
+++ b/plugins/openclaw-qqbot/package-lock.json
@@ -8,53 +8,30 @@
       "name": "@crabpot/fixture-openclaw-qqbot",
       "version": "0.0.0",
       "dependencies": {
-        "@openclaw/qqbot": "2026.7.2-beta.4"
+        "@tencent-connect/openclaw-qqbot": "2.0.1"
       }
     },
-    "node_modules/@openclaw/qqbot": {
-      "version": "2026.7.2-beta.4",
-      "resolved": "https://registry.npmjs.org/@openclaw/qqbot/-/qqbot-2026.7.2-beta.4.tgz",
-      "integrity": "sha512-6VsbHjn2JBP+0wxvbBvd/jP4pYvyHO4wUloG42xx2b4VScD7XA4rgXI/7F5SV+KRDslzelzUgoguDYIxTzj9hg==",
-      "bundleDependencies": [
-        "@tencent-connect/qqbot-connector",
-        "mpg123-decoder",
-        "p-map",
-        "pretty-ms",
-        "silk-wasm",
-        "ws",
-        "zod"
-      ],
-      "hasShrinkwrap": true,
+    "node_modules/@tencent-connect/openclaw-qqbot": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tencent-connect/openclaw-qqbot/-/openclaw-qqbot-2.0.1.tgz",
+      "integrity": "sha512-2010PaCummeQaxerLtaGfQ/5HChiXaW/KpTERid7V/1zyTs46S2ACi0hgZQ1SB7tH0t1InWr8tzVBJV/pLss3Q==",
       "dependencies": {
         "@tencent-connect/qqbot-connector": "1.2.0",
-        "mpg123-decoder": "1.0.3",
-        "p-map": "7.0.5",
-        "pretty-ms": "9.3.0",
-        "silk-wasm": "3.7.1",
-        "ws": "8.21.1",
-        "zod": "4.4.3"
+        "@tencent-connect/qqbot-nodejs": "^1.0.4"
+      },
+      "bin": {
+        "openclaw-qqbot": "bin/qqbot-cli.js",
+        "qqbot": "bin/qqbot-cli.js"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.7.2-beta.4"
-      },
-      "peerDependenciesMeta": {
-        "openclaw": {
-          "optional": true
-        }
+        "@tencent-connect/qqbot-connector": "1.2.0",
+        "openclaw": "*"
       }
     },
-    "node_modules/@openclaw/qqbot/node_modules/@eshaz/web-worker": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eshaz/web-worker/-/web-worker-1.2.2.tgz",
-      "integrity": "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==",
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@openclaw/qqbot/node_modules/@tencent-connect/qqbot-connector": {
+    "node_modules/@tencent-connect/qqbot-connector": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@tencent-connect/qqbot-connector/-/qqbot-connector-1.2.0.tgz",
       "integrity": "sha512-FAOUCvgxP4M9UiYbHrtVgJ7BavSlh1CHJPjeEQuTAkP9MZ91lX4yATqv6I/lB9yp15nVq+G2DaGSSJwQTSoSsA==",
-      "inBundle": true,
       "license": "UNLICENSED",
       "dependencies": {
         "qrcode-terminal": "^0.12"
@@ -63,108 +40,42 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@openclaw/qqbot/node_modules/@wasm-audio-decoders/common": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/common/-/common-9.0.7.tgz",
-      "integrity": "sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==",
-      "inBundle": true,
+    "node_modules/@tencent-connect/qqbot-nodejs": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tencent-connect/qqbot-nodejs/-/qqbot-nodejs-1.0.4.tgz",
+      "integrity": "sha512-gU5HySLplczZXMUjM7NtiUACY7YfX9YlI/R9PKzCLMgLmHvwsX9L2sitsrYPMentGUr9b8NLfSaSTsndF77NBA==",
       "license": "MIT",
       "dependencies": {
-        "@eshaz/web-worker": "1.2.2",
-        "simple-yenc": "^1.0.4"
-      }
-    },
-    "node_modules/@openclaw/qqbot/node_modules/mpg123-decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mpg123-decoder/-/mpg123-decoder-1.0.3.tgz",
-      "integrity": "sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wasm-audio-decoders/common": "9.0.7"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
-      }
-    },
-    "node_modules/@openclaw/qqbot/node_modules/p-map": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@openclaw/qqbot/node_modules/parse-ms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@openclaw/qqbot/node_modules/pretty-ms": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
-      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^4.0.0"
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=18"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "peerDependencies": {
+        "mpg123-decoder": "^1.0.3",
+        "silk-wasm": "^3.7.1"
+      },
+      "peerDependenciesMeta": {
+        "mpg123-decoder": {
+          "optional": true
+        },
+        "silk-wasm": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@openclaw/qqbot/node_modules/qrcode-terminal": {
+    "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
       "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
-      "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
-    "node_modules/@openclaw/qqbot/node_modules/silk-wasm": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/silk-wasm/-/silk-wasm-3.7.1.tgz",
-      "integrity": "sha512-mXPwLRtZxrYV3TZx41jMAeKc80wvmyrcXIcs8HctFxK15Ahz2OJQENYhNgEPeCEOdI6Mbx1NxQsqxzwc3DKerw==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.11.0"
-      }
-    },
-    "node_modules/@openclaw/qqbot/node_modules/simple-yenc": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-1.0.4.tgz",
-      "integrity": "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==",
-      "inBundle": true,
-      "license": "MIT",
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
-      }
-    },
-    "node_modules/@openclaw/qqbot/node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-      "inBundle": true,
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -180,16 +91,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@openclaw/qqbot/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/plugins/openclaw-qqbot/package.json
+++ b/plugins/openclaw-qqbot/package.json
@@ -4,17 +4,17 @@
   "private": true,
   "description": "Crabpot npm fixture shim for OpenClaw QQ Bot channel plugin.",
   "dependencies": {
-    "@openclaw/qqbot": "2026.7.2-beta.4"
+    "@tencent-connect/openclaw-qqbot": "2.0.1"
   },
   "crabpot": {
     "fixture": "openclaw-qqbot",
     "source": "npm",
-    "package": "@openclaw/qqbot",
-    "sourceRepo": "https://github.com/openclaw/openclaw.git",
-    "sourcePath": "extensions/qqbot",
-    "sourceRef": "10ad3aa16068baa84a1bd9ac4f7d42ae725cedb7"
+    "package": "@tencent-connect/openclaw-qqbot",
+    "sourceRepo": "https://github.com/tencent-connect/openclaw-qqbot.git",
+    "sourcePath": ".",
+    "sourceRef": "88dee0b0e493469dc8c1684a5beafcbc66aa5bda"
   },
   "overrides": {
-    "ws": "8.20.1"
+    "ws": "8.21.0"
   }
 }

--- a/scripts/source-package-candidates.mjs
+++ b/scripts/source-package-candidates.mjs
@@ -1,0 +1,96 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const ignoredDirectories = new Set([".git", ".pnpm", "node_modules"]);
+
+export async function findNearbySourcePackageCandidates({
+  expectedPackageName,
+  limit = 5,
+  missingSourcePath,
+  sourceRoot,
+}) {
+  const packageJsonPaths = [];
+  await collectPackageJsonPaths(sourceRoot, sourceRoot, packageJsonPaths);
+
+  const candidates = await Promise.all(
+    packageJsonPaths.map(async (packageJsonPath) => {
+      let packageName = "";
+      try {
+        packageName = JSON.parse(await readFile(packageJsonPath, "utf8")).name ?? "";
+      } catch {
+        // A malformed unrelated package should not hide useful candidates.
+      }
+      const relativePath = path.relative(sourceRoot, packageJsonPath);
+      const sourcePath = path.dirname(relativePath);
+      return {
+        distance: editDistance(missingSourcePath, sourcePath),
+        exactPackageName: packageName === expectedPackageName,
+        packageName,
+        relativePath,
+      };
+    }),
+  );
+
+  return candidates
+    .sort((left, right) => {
+      if (left.exactPackageName !== right.exactPackageName) {
+        return left.exactPackageName ? -1 : 1;
+      }
+      return left.distance - right.distance || left.relativePath.localeCompare(right.relativePath);
+    })
+    .slice(0, limit)
+    .map(({ packageName, relativePath }) => ({ packageName, relativePath }));
+}
+
+export function formatMissingSourcePackageMessage({ candidates, fixtureId, packageJsonPath }) {
+  const candidateLines = candidates.map(
+    (candidate) =>
+      `  - ${candidate.relativePath}${candidate.packageName ? ` (${candidate.packageName})` : ""}`,
+  );
+  const candidateDetail =
+    candidateLines.length > 0
+      ? `\nNearby package.json candidates in the OpenClaw checkout:\n${candidateLines.join("\n")}`
+      : "\nNo package.json candidates were found in the OpenClaw checkout.";
+  return `${fixtureId}: missing source package.json at ${packageJsonPath}.${candidateDetail}\nUpdate source.path in crabpot.config.json if the package moved.`;
+}
+
+async function collectPackageJsonPaths(sourceRoot, currentDirectory, results) {
+  let entries;
+  try {
+    entries = await readdir(currentDirectory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(currentDirectory, entry.name);
+    if (entry.isFile() && entry.name === "package.json") {
+      results.push(entryPath);
+      continue;
+    }
+    if (
+      entry.isDirectory() &&
+      !ignoredDirectories.has(entry.name) &&
+      !entry.name.startsWith(".crabpot") &&
+      entryPath !== sourceRoot
+    ) {
+      await collectPackageJsonPaths(sourceRoot, entryPath, results);
+    }
+  }
+}
+
+function editDistance(left, right) {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      current[rightIndex] = Math.min(
+        current[rightIndex - 1] + 1,
+        previous[rightIndex] + 1,
+        previous[rightIndex - 1] + (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1),
+      );
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+  return previous[right.length];
+}

--- a/scripts/sync-fixtures.mjs
+++ b/scripts/sync-fixtures.mjs
@@ -11,6 +11,10 @@ import {
   resolveNpmViewVersion,
 } from "./npm-pack-result.mjs";
 import { writePackageAvailabilityReport } from "./package-availability.mjs";
+import {
+  findNearbySourcePackageCandidates,
+  formatMissingSourcePackageMessage,
+} from "./source-package-candidates.mjs";
 
 const openclawSourceRepo = "https://github.com/openclaw/openclaw.git";
 const sourcePackPluginTrack = "source-pack";
@@ -156,7 +160,18 @@ async function materializeSourcePackFixture(fixture, target) {
 
   const packageJsonPath = path.join(sourceDir, "package.json");
   if (!existsSync(packageJsonPath)) {
-    throw new Error(`${fixture.id}: missing source package.json at ${path.relative(repoRoot, packageJsonPath)}`);
+    const candidates = await findNearbySourcePackageCandidates({
+      expectedPackageName: fixture.package.name,
+      missingSourcePath: fixture.source.path,
+      sourceRoot: openclawRoot,
+    });
+    throw new Error(
+      formatMissingSourcePackageMessage({
+        candidates,
+        fixtureId: fixture.id,
+        packageJsonPath: path.relative(repoRoot, packageJsonPath),
+      }),
+    );
   }
   const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
   if (packageJson.name !== fixture.package.name) {

--- a/test/manifest.test.mjs
+++ b/test/manifest.test.mjs
@@ -35,7 +35,7 @@ test("fixture manifest is valid and seam-rich", async () => {
   }
 });
 
-test("openclaw beta fixture set narrows to beta npm packages", async () => {
+test("openclaw development fixture set includes current monorepo and externalized packages", async () => {
   const manifest = await readConfiguredManifest({ fixtureSet: "openclaw-beta" });
 
   assert.deepEqual(manifest.fixtures.map((fixture) => fixture.id), [
@@ -48,7 +48,18 @@ test("openclaw beta fixture set narrows to beta npm packages", async () => {
     "openclaw-qqbot",
     "whatsapp",
   ]);
-  assert.ok(manifest.fixtures.every((fixture) => fixture.package?.tag === "beta"));
+  assert.ok(
+    manifest.fixtures
+      .filter((fixture) => fixture.id !== "openclaw-qqbot")
+      .every((fixture) => fixture.package?.tag === "beta"),
+  );
+  const qqbot = manifest.fixtures.find((fixture) => fixture.id === "openclaw-qqbot");
+  assert.equal(qqbot.package.name, "@tencent-connect/openclaw-qqbot");
+  assert.equal(qqbot.package.version, "2.0.1");
+  assert.equal(qqbot.source.repo, "https://github.com/tencent-connect/openclaw-qqbot.git");
+  assert.equal(qqbot.source.path, ".");
+  assert.deepEqual(qqbot.expect.registrations, ["registerChannel", "registerTool"]);
+  assert.equal(qqbot.execution, undefined);
 });
 
 test("Codex fixture follows current provider ownership", async () => {

--- a/test/source-package-candidates.test.mjs
+++ b/test/source-package-candidates.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  findNearbySourcePackageCandidates,
+  formatMissingSourcePackageMessage,
+} from "../scripts/source-package-candidates.mjs";
+
+test("source package candidates put an exact package-name move first", async (context) => {
+  const sourceRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-source-candidates-"));
+  context.after(() => rm(sourceRoot, { recursive: true, force: true }));
+
+  await writePackage(sourceRoot, "extensions/qq-helper", "@openclaw/qq-helper");
+  await writePackage(sourceRoot, "packages/channels/qqbot", "@openclaw/qqbot");
+  await writePackage(sourceRoot, "extensions/qwen", "@openclaw/qwen");
+
+  const candidates = await findNearbySourcePackageCandidates({
+    expectedPackageName: "@openclaw/qqbot",
+    missingSourcePath: "extensions/qqbot",
+    sourceRoot,
+  });
+
+  assert.deepEqual(candidates[0], {
+    packageName: "@openclaw/qqbot",
+    relativePath: path.join("packages", "channels", "qqbot", "package.json"),
+  });
+  assert.equal(candidates.length, 3);
+});
+
+test("source package candidates ignore dependencies and malformed package metadata", async (context) => {
+  const sourceRoot = await mkdtemp(path.join(os.tmpdir(), "crabpot-source-candidates-"));
+  context.after(() => rm(sourceRoot, { recursive: true, force: true }));
+
+  await writePackage(sourceRoot, "node_modules/qqbot", "@openclaw/qqbot");
+  await mkdir(path.join(sourceRoot, "extensions", "qqbot-next"), { recursive: true });
+  await writeFile(path.join(sourceRoot, "extensions", "qqbot-next", "package.json"), "not json");
+
+  const candidates = await findNearbySourcePackageCandidates({
+    expectedPackageName: "@openclaw/qqbot",
+    missingSourcePath: "extensions/qqbot",
+    sourceRoot,
+  });
+
+  assert.deepEqual(candidates, [
+    { packageName: "", relativePath: path.join("extensions", "qqbot-next", "package.json") },
+  ]);
+});
+
+test("missing source package message identifies candidate paths and the manifest repair", () => {
+  const message = formatMissingSourcePackageMessage({
+    candidates: [
+      {
+        packageName: "@openclaw/qqbot",
+        relativePath: "packages/channels/qqbot/package.json",
+      },
+    ],
+    fixtureId: "openclaw-qqbot",
+    packageJsonPath: "openclaw/extensions/qqbot/package.json",
+  });
+
+  assert.match(message, /openclaw-qqbot: missing source package\.json/);
+  assert.match(message, /packages\/channels\/qqbot\/package\.json \(@openclaw\/qqbot\)/);
+  assert.match(message, /Update source\.path in crabpot\.config\.json/);
+});
+
+async function writePackage(sourceRoot, sourcePath, packageName) {
+  const directory = path.join(sourceRoot, sourcePath);
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, "package.json"), JSON.stringify({ name: packageName }));
+}


### PR DESCRIPTION
## Summary

- follow OpenClaw's externalization of QQbot to `@tencent-connect/openclaw-qqbot@2.0.1` and its Tencent repository root
- refresh the fixture lock and expected `registerChannel` / `registerTool` surface
- make a missing source-pack path list nearby `package.json` candidates and the manifest field to update

## Root cause

OpenClaw removed `extensions/qqbot` and now declares QQbot through its official external-channel catalog. Crabpot still treated `@openclaw/qqbot` as a source-packed monorepo package, so every development dashboard refresh stopped at fixture materialization.

The other seven source fixtures selected by `openclaw-beta` still exist at their configured paths on OpenClaw `main`.

This unblocks the repeated failures visible in [run 31692193707](https://github.com/openclaw/crabpot/actions/runs/31692193707) and the latest observed [run 31745351508](https://github.com/openclaw/crabpot/actions/runs/31745351508).

## Proof

- `CRABPOT_FIXTURE_SET=openclaw-beta CRABPOT_PLUGIN_TRACK=source-pack CRABPOT_OPENCLAW_TRACK=development node scripts/sync-fixtures.mjs --materialize --openclaw ./.crabpot/openclaw-source --no-package-availability-report` — fixtures materialized against OpenClaw `b7b33149b06e6e371879c7a5f0846b68880226e2`
- focused manifest, workflow, static-suite, and candidate-diagnostic tests — 31 passed
- selected strict contract smoke and fixture inspection — all eight fixtures `ok`
- `npm --prefix plugins/openclaw-qqbot audit --omit=dev` — 0 vulnerabilities
- structured autoreview — clean
