### PR TITLE
fix(ci): isolate manual ref runs from default branch cache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
   push:
     branches: [main, crab-beta, crab-development]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -28,11 +27,6 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "audit=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           base="${BASE_SHA}"
           head="${HEAD_SHA}"
           if [ -z "${base}" ] || [[ "${base}" =~ ^0+$ ]]; then

--- a/.github/workflows/openclaw-ref-compat-run.yml
+++ b/.github/workflows/openclaw-ref-compat-run.yml
@@ -1,0 +1,376 @@
+name: OpenClaw Ref Compatibility Run
+
+on:
+  push:
+    branches:
+      - "openclaw-ref-run/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openclaw-ref-compat-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  request:
+    name: Validate compatibility request
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.request.outputs.mode }}
+      openclaw_repository: ${{ steps.request.outputs.openclaw_repository }}
+      openclaw_ref: ${{ steps.request.outputs.openclaw_ref }}
+      base_openclaw_repository: ${{ steps.request.outputs.base_openclaw_repository }}
+      base_openclaw_ref: ${{ steps.request.outputs.base_openclaw_ref }}
+      head_openclaw_repository: ${{ steps.request.outputs.head_openclaw_repository }}
+      head_openclaw_ref: ${{ steps.request.outputs.head_openclaw_ref }}
+      fixture_set: ${{ steps.request.outputs.fixture_set }}
+      run_isolated_fixture: ${{ steps.request.outputs.run_isolated_fixture }}
+      fixture: ${{ steps.request.outputs.fixture }}
+      profile_runs: ${{ steps.request.outputs.profile_runs }}
+      strict_contract: ${{ steps.request.outputs.strict_contract }}
+      strict_perf: ${{ steps.request.outputs.strict_perf }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Validate and load request
+        id: request
+        shell: bash
+        run: |
+          set -euo pipefail
+          request=.github/openclaw-ref-request.json
+          test -f "${request}"
+          jq -e '
+            (.mode | IN("static", "diff", "isolated", "full")) and
+            (.profile_runs | test("^[1-9][0-9]*$")) and
+            (.fixture_set | test("^[A-Za-z0-9_.-]+(,[A-Za-z0-9_.-]+)*$")) and
+            (.fixture | test("^$|^[A-Za-z0-9_.-]+$")) and
+            (.run_isolated_fixture | type == "boolean") and
+            (.strict_contract | type == "boolean") and
+            (.strict_perf | type == "boolean") and
+            ([.openclaw_repository, .base_openclaw_repository, .head_openclaw_repository] |
+              all(test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"))) and
+            ([.openclaw_ref, .base_openclaw_ref, .head_openclaw_ref] |
+              all(length > 0 and (test("[[:cntrl:][:space:]]") | not)))
+          ' "${request}" >/dev/null
+          for key in \
+            mode \
+            openclaw_repository \
+            openclaw_ref \
+            base_openclaw_repository \
+            base_openclaw_ref \
+            head_openclaw_repository \
+            head_openclaw_ref \
+            fixture_set \
+            run_isolated_fixture \
+            fixture \
+            profile_runs \
+            strict_contract \
+            strict_perf; do
+            printf '%s=%s\n' "${key}" "$(jq -r ".${key}" "${request}")" >> "$GITHUB_OUTPUT"
+          done
+
+  static-contract:
+    name: Static contract against selected OpenClaw ref
+    runs-on: ubuntu-latest
+    needs: request
+    env:
+      TARGET_REPOSITORY: ${{ (needs.request.outputs.mode == 'diff' || needs.request.outputs.mode == 'full') && needs.request.outputs.head_openclaw_repository || needs.request.outputs.openclaw_repository }}
+      TARGET_REF: ${{ (needs.request.outputs.mode == 'diff' || needs.request.outputs.mode == 'full') && needs.request.outputs.head_openclaw_ref || needs.request.outputs.openclaw_ref }}
+      PROFILE_RUNS: ${{ needs.request.outputs.profile_runs }}
+      STRICT_CONTRACT: ${{ needs.request.outputs.strict_contract }}
+      STRICT_PERF: ${{ needs.request.outputs.strict_perf }}
+      SUITE_POLICY: ${{ needs.request.outputs.strict_contract == 'true' && 'release' || 'dashboard' }}
+    steps:
+      - name: Checkout Crabpot
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Checkout target OpenClaw
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.TARGET_REPOSITORY }}
+          ref: ${{ env.TARGET_REF }}
+          path: openclaw
+
+      - name: Show target revision
+        env:
+          TARGET_LABEL: ${{ env.TARGET_REPOSITORY }}@${{ env.TARGET_REF }}
+        run: |
+          echo "repository=${TARGET_REPOSITORY}"
+          echo "ref=${TARGET_REF}"
+          git -C openclaw rev-parse HEAD
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - run: node scripts/run-static-suite.mjs --openclaw ./openclaw --policy "${SUITE_POLICY}" --profile-runs "${PROFILE_RUNS}" --plugin-inspector-smoke
+      - name: Run runtime profile policy
+        run: node scripts/compare-runtime-profile.mjs ${{ needs.request.outputs.strict_perf == 'true' && '--strict' || '' }}
+      - run: node scripts/check-contract-coverage.mjs --openclaw ./openclaw
+      - name: Install OpenClaw lifecycle dependencies
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./openclaw/package.json').packageManager.split('+')[0]")" --activate
+          pnpm --dir openclaw install --frozen-lockfile --ignore-scripts
+
+      - name: Write report artifacts
+        if: always()
+        continue-on-error: true
+        run: |
+          node scripts/generate-report.mjs --openclaw ./openclaw
+          node scripts/capture-contracts.mjs --openclaw ./openclaw
+          node scripts/synthetic-probes.mjs --openclaw ./openclaw
+          node scripts/cold-import-readiness.mjs --openclaw ./openclaw
+          node scripts/workspace-plan.mjs --openclaw ./openclaw
+          node scripts/platform-probes.mjs --openclaw ./openclaw
+          node scripts/check-generated-surface-fixture.mjs --openclaw ./openclaw
+          node scripts/import-loop-profile.mjs --openclaw ./openclaw --runs "${PROFILE_RUNS}"
+          node scripts/profile-contract-runtime.mjs --openclaw ./openclaw --runs "${PROFILE_RUNS}"
+          node scripts/compare-runtime-profile.mjs ${{ needs.request.outputs.strict_perf == 'true' && '--strict' || '' }}
+          node scripts/check-ci-policy.mjs ${{ needs.request.outputs.strict_contract == 'true' && '--strict' || '' }}
+          node scripts/write-ci-summary.mjs --mode "${{ needs.request.outputs.mode }}" --openclaw-label "${TARGET_REPOSITORY}@${TARGET_REF}" --github-step-summary
+
+      - name: Upload static compatibility reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crabpot-openclaw-ref-static-reports
+          path: reports/
+          if-no-files-found: warn
+
+  ref-diff:
+    name: Compare base and head OpenClaw refs
+    runs-on: ubuntu-latest
+    needs: request
+    if: ${{ needs.request.outputs.mode == 'diff' || needs.request.outputs.mode == 'full' }}
+    permissions:
+      contents: read
+    env:
+      PROFILE_RUNS: ${{ needs.request.outputs.profile_runs }}
+    steps:
+      - name: Checkout Crabpot
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Checkout base OpenClaw
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ needs.request.outputs.base_openclaw_repository }}
+          ref: ${{ needs.request.outputs.base_openclaw_ref }}
+          path: openclaw-base
+
+      - name: Checkout head OpenClaw
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ needs.request.outputs.head_openclaw_repository }}
+          ref: ${{ needs.request.outputs.head_openclaw_ref }}
+          path: openclaw-head
+
+      - name: Show compared revisions
+        env:
+          BASE_LABEL: ${{ needs.request.outputs.base_openclaw_repository }}@${{ needs.request.outputs.base_openclaw_ref }}
+          HEAD_LABEL: ${{ needs.request.outputs.head_openclaw_repository }}@${{ needs.request.outputs.head_openclaw_ref }}
+        run: |
+          echo "base=${BASE_LABEL}"
+          git -C openclaw-base rev-parse HEAD
+          echo "head=${HEAD_LABEL}"
+          git -C openclaw-head rev-parse HEAD
+          ln -s openclaw-head openclaw
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - run: node scripts/sync-fixtures.mjs --materialize --openclaw ./openclaw
+      - run: npm test
+      - name: Compare OpenClaw refs
+        env:
+          BASE_LABEL: ${{ needs.request.outputs.base_openclaw_repository }}@${{ needs.request.outputs.base_openclaw_ref }}
+          HEAD_LABEL: ${{ needs.request.outputs.head_openclaw_repository }}@${{ needs.request.outputs.head_openclaw_ref }}
+        run: |
+          node scripts/compare-openclaw-refs.mjs \
+            --base-openclaw ./openclaw-base \
+            --head-openclaw ./openclaw-head \
+            --base-label "${BASE_LABEL}" \
+            --head-label "${HEAD_LABEL}" \
+            ${{ needs.request.outputs.strict_contract == 'true' && '--strict' || '' }}
+      - name: Run runtime profile policy
+        run: |
+          node scripts/profile-contract-runtime.mjs --openclaw ./openclaw-head --runs "${PROFILE_RUNS}"
+          node scripts/compare-runtime-profile.mjs ${{ needs.request.outputs.strict_perf == 'true' && '--strict' || '' }}
+
+      - name: Write ref diff summary
+        if: always()
+        continue-on-error: true
+        env:
+          OPENCLAW_LABEL: ${{ needs.request.outputs.base_openclaw_repository }}@${{ needs.request.outputs.base_openclaw_ref }}..${{ needs.request.outputs.head_openclaw_repository }}@${{ needs.request.outputs.head_openclaw_ref }}
+        run: |
+          node scripts/profile-contract-runtime.mjs --openclaw ./openclaw-head --runs "${PROFILE_RUNS}"
+          node scripts/compare-runtime-profile.mjs ${{ needs.request.outputs.strict_perf == 'true' && '--strict' || '' }}
+          node scripts/check-ci-policy.mjs ${{ needs.request.outputs.strict_contract == 'true' && '--strict' || '' }}
+          node scripts/write-ci-summary.mjs --mode "${{ needs.request.outputs.mode }}" --openclaw-label "${OPENCLAW_LABEL}" --github-step-summary
+
+      - name: Upload ref diff reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crabpot-openclaw-ref-diff-reports
+          path: reports/
+          if-no-files-found: warn
+
+  fixture-plan:
+    name: Resolve isolated fixture set
+    runs-on: ubuntu-latest
+    needs: request
+    if: ${{ needs.request.outputs.mode == 'isolated' || needs.request.outputs.mode == 'full' || (needs.request.outputs.run_isolated_fixture == 'true' && needs.request.outputs.fixture != '') }}
+    outputs:
+      matrix: ${{ steps.resolve.outputs.matrix }}
+      count: ${{ steps.resolve.outputs.count }}
+      fixtures: ${{ steps.resolve.outputs.fixtures }}
+    permissions:
+      contents: read
+    env:
+      TARGET_REPOSITORY: ${{ (needs.request.outputs.mode == 'full') && needs.request.outputs.head_openclaw_repository || needs.request.outputs.openclaw_repository }}
+      TARGET_REF: ${{ (needs.request.outputs.mode == 'full') && needs.request.outputs.head_openclaw_ref || needs.request.outputs.openclaw_ref }}
+    steps:
+      - name: Checkout Crabpot
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Checkout target OpenClaw
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.TARGET_REPOSITORY }}
+          ref: ${{ env.TARGET_REF }}
+          path: openclaw
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Resolve fixture matrix
+        id: resolve
+        env:
+          INPUT_FIXTURE_SET: ${{ needs.request.outputs.fixture_set }}
+          INPUT_FIXTURE: ${{ needs.request.outputs.fixture }}
+          INPUT_RUN_ISOLATED_FIXTURE: ${{ needs.request.outputs.run_isolated_fixture }}
+        run: |
+          fixture_set="${INPUT_FIXTURE_SET}"
+          if [ "${INPUT_RUN_ISOLATED_FIXTURE}" = "true" ] && [ -n "${INPUT_FIXTURE}" ]; then
+            fixture_set="${INPUT_FIXTURE}"
+          fi
+          node scripts/resolve-fixture-set.mjs \
+            --fixture-set "${fixture_set}" \
+            --openclaw ./openclaw \
+            --allow-empty \
+            --github-output >> "$GITHUB_OUTPUT"
+
+      - name: Show selected fixtures
+        run: echo "fixtures=${{ steps.resolve.outputs.fixtures }}"
+
+  isolated-fixture:
+    name: Isolated fixture ${{ matrix.id }}
+    runs-on: ubuntu-latest
+    needs: [request, fixture-plan]
+    if: ${{ needs.fixture-plan.outputs.count != '0' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.fixture-plan.outputs.matrix) }}
+    permissions:
+      contents: read
+    env:
+      TARGET_REPOSITORY: ${{ (needs.request.outputs.mode == 'full') && needs.request.outputs.head_openclaw_repository || needs.request.outputs.openclaw_repository }}
+      TARGET_REF: ${{ (needs.request.outputs.mode == 'full') && needs.request.outputs.head_openclaw_ref || needs.request.outputs.openclaw_ref }}
+    steps:
+      - name: Checkout Crabpot
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Checkout target OpenClaw
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.TARGET_REPOSITORY }}
+          ref: ${{ env.TARGET_REF }}
+          path: openclaw
+
+      - name: Show target revision
+        run: |
+          echo "repository=${TARGET_REPOSITORY}"
+          echo "ref=${TARGET_REF}"
+          git -C openclaw rev-parse HEAD
+          echo "fixture=${{ matrix.id }}"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Validate workspace plan
+        run: node scripts/workspace-plan.mjs --check --openclaw ./openclaw
+
+      - name: Execute fixture lane
+        id: execute
+        continue-on-error: true
+        env:
+          CRABPOT_EXECUTE_ISOLATED: "1"
+        run: npm run workspace:execute -- --fixture "${{ matrix.id }}" --allow-empty --openclaw ./openclaw
+
+      - name: Summarize execution artifacts
+        if: always()
+        continue-on-error: true
+        run: npm run execution:report
+
+      - name: Reconcile compatibility report with runtime evidence
+        if: always()
+        continue-on-error: true
+        run: node scripts/generate-report.mjs --openclaw ./openclaw --execution-results reports/crabpot-execution-results.json --fixture-set "${{ matrix.id }}"
+
+      - name: Run execution policy
+        id: policy
+        if: always()
+        continue-on-error: true
+        run: node scripts/check-ci-policy.mjs ${{ needs.request.outputs.strict_contract == 'true' && '--strict' || '' }}
+
+      - name: Write isolated summary
+        if: always()
+        continue-on-error: true
+        run: node scripts/write-ci-summary.mjs --mode "${{ needs.request.outputs.mode }}" --openclaw-label "${TARGET_REPOSITORY}@${TARGET_REF}" --github-step-summary
+
+      - name: Upload isolated execution artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crabpot-openclaw-ref-isolated-${{ matrix.id }}
+          path: |
+            .crabpot/results/
+            reports/crabpot-report.*
+            reports/crabpot-issues.*
+            reports/crabpot-execution-results.*
+            reports/crabpot-ci-policy.*
+            reports/crabpot-ci-summary.*
+          if-no-files-found: warn
+
+      - name: Fail if isolated execution failed
+        if: ${{ steps.execute.outcome == 'failure' || steps.policy.outcome == 'failure' }}
+        run: exit 1
+
+  cleanup:
+    name: Delete ephemeral compatibility branch
+    runs-on: ubuntu-latest
+    needs: [request, static-contract, ref-diff, fixture-plan, isolated-fixture]
+    if: ${{ always() && startsWith(github.ref_name, 'openclaw-ref-run/') }}
+    permissions:
+      contents: write
+    steps:
+      - name: Delete request branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_BRANCH: ${{ github.ref_name }}
+        run: gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${RUN_BRANCH}"

--- a/.github/workflows/openclaw-ref-compat-stage.yml
+++ b/.github/workflows/openclaw-ref-compat-stage.yml
@@ -1,0 +1,110 @@
+name: OpenClaw Ref Compatibility Stage
+
+on:
+  workflow_run:
+    workflows: ["OpenClaw Ref Compatibility"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: openclaw-ref-compat-stage-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  stage:
+    name: Stage branch-scoped compatibility run
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'workflow_dispatch' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download compatibility request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          mkdir request
+          gh run download "${SOURCE_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name openclaw-ref-compat-request \
+            --dir request
+          test -f request/openclaw-ref-request.json
+          test ! -L request/openclaw-ref-request.json
+          test "$(find request -type f | wc -l)" -eq 1
+          test "$(wc -c < request/openclaw-ref-request.json)" -le 16384
+
+      - name: Validate compatibility request
+        run: |
+          set -euo pipefail
+          request=request/openclaw-ref-request.json
+          jq -e '
+            (keys | sort) == ([
+              "base_openclaw_ref",
+              "base_openclaw_repository",
+              "fixture",
+              "fixture_set",
+              "head_openclaw_ref",
+              "head_openclaw_repository",
+              "mode",
+              "openclaw_ref",
+              "openclaw_repository",
+              "profile_runs",
+              "run_isolated_fixture",
+              "strict_contract",
+              "strict_perf"
+            ] | sort) and
+            (.mode | IN("static", "diff", "isolated", "full")) and
+            (.profile_runs | test("^[1-9][0-9]*$")) and
+            (.fixture_set | test("^[A-Za-z0-9_.-]+(,[A-Za-z0-9_.-]+)*$")) and
+            (.fixture | test("^$|^[A-Za-z0-9_.-]+$")) and
+            (.run_isolated_fixture | type == "boolean") and
+            (.strict_contract | type == "boolean") and
+            (.strict_perf | type == "boolean") and
+            ([.openclaw_repository, .base_openclaw_repository, .head_openclaw_repository] |
+              all(test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"))) and
+            ([.openclaw_ref, .base_openclaw_ref, .head_openclaw_ref] |
+              all(length > 0 and (test("[[:cntrl:][:space:]]") | not)))
+          ' "${request}" >/dev/null
+
+      - name: Create branch dispatch token
+        id: branch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: Iv23liOECG0slfuhz093
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      - name: Checkout trusted Crabpot source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          path: crabpot
+          token: ${{ steps.branch-token.outputs.token }}
+
+      - name: Push ephemeral compatibility branch
+        env:
+          RUN_BRANCH: openclaw-ref-run/${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          cp request/openclaw-ref-request.json crabpot/.github/openclaw-ref-request.json
+          git -C crabpot config user.name "github-actions[bot]"
+          git -C crabpot config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C crabpot checkout -b "${RUN_BRANCH}"
+          git -C crabpot add .github/openclaw-ref-request.json
+          git -C crabpot commit -m "ci: stage OpenClaw ref compatibility request"
+          git -C crabpot push origin "HEAD:refs/heads/${RUN_BRANCH}"
+          {
+            echo "Compatibility execution was staged on \`${RUN_BRANCH}\`."
+            echo
+            echo "The branch-scoped run will delete the branch after completion."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/openclaw-ref-compat.yml
+++ b/.github/workflows/openclaw-ref-compat.yml
@@ -65,291 +65,78 @@ on:
         required: true
         default: false
 
+permissions:
+  contents: write
+
 jobs:
-  static-contract:
-    name: Static contract against selected OpenClaw ref
+  dispatch:
+    name: Stage branch-scoped compatibility run
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      TARGET_REPOSITORY: ${{ (inputs.mode == 'diff' || inputs.mode == 'full') && inputs.head_openclaw_repository || inputs.openclaw_repository }}
-      TARGET_REF: ${{ (inputs.mode == 'diff' || inputs.mode == 'full') && inputs.head_openclaw_ref || inputs.openclaw_ref }}
-      PROFILE_RUNS: ${{ inputs.profile_runs }}
-      STRICT_CONTRACT: ${{ inputs.strict_contract }}
-      STRICT_PERF: ${{ inputs.strict_perf }}
-      SUITE_POLICY: ${{ inputs.strict_contract && 'release' || 'dashboard' }}
     steps:
-      - name: Checkout Crabpot
+      - name: Checkout trusted Crabpot source
         uses: actions/checkout@v6
         with:
-          submodules: recursive
+          ref: ${{ github.sha }}
+          fetch-depth: 1
 
-      - name: Checkout target OpenClaw
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.TARGET_REPOSITORY }}
-          ref: ${{ env.TARGET_REF }}
-          path: openclaw
-
-      - name: Show target revision
+      - name: Write compatibility request
         env:
-          TARGET_LABEL: ${{ env.TARGET_REPOSITORY }}@${{ env.TARGET_REF }}
+          MODE: ${{ inputs.mode }}
+          OPENCLAW_REPOSITORY: ${{ inputs.openclaw_repository }}
+          OPENCLAW_REF: ${{ inputs.openclaw_ref }}
+          BASE_OPENCLAW_REPOSITORY: ${{ inputs.base_openclaw_repository }}
+          BASE_OPENCLAW_REF: ${{ inputs.base_openclaw_ref }}
+          HEAD_OPENCLAW_REPOSITORY: ${{ inputs.head_openclaw_repository }}
+          HEAD_OPENCLAW_REF: ${{ inputs.head_openclaw_ref }}
+          FIXTURE_SET: ${{ inputs.fixture_set }}
+          RUN_ISOLATED_FIXTURE: ${{ inputs.run_isolated_fixture }}
+          FIXTURE: ${{ inputs.fixture }}
+          PROFILE_RUNS: ${{ inputs.profile_runs }}
+          STRICT_CONTRACT: ${{ inputs.strict_contract }}
+          STRICT_PERF: ${{ inputs.strict_perf }}
         run: |
-          echo "repository=${TARGET_REPOSITORY}"
-          echo "ref=${TARGET_REF}"
-          git -C openclaw rev-parse HEAD
+          jq -n \
+            --arg mode "${MODE}" \
+            --arg openclaw_repository "${OPENCLAW_REPOSITORY}" \
+            --arg openclaw_ref "${OPENCLAW_REF}" \
+            --arg base_openclaw_repository "${BASE_OPENCLAW_REPOSITORY}" \
+            --arg base_openclaw_ref "${BASE_OPENCLAW_REF}" \
+            --arg head_openclaw_repository "${HEAD_OPENCLAW_REPOSITORY}" \
+            --arg head_openclaw_ref "${HEAD_OPENCLAW_REF}" \
+            --arg fixture_set "${FIXTURE_SET}" \
+            --argjson run_isolated_fixture "${RUN_ISOLATED_FIXTURE}" \
+            --arg fixture "${FIXTURE}" \
+            --arg profile_runs "${PROFILE_RUNS}" \
+            --argjson strict_contract "${STRICT_CONTRACT}" \
+            --argjson strict_perf "${STRICT_PERF}" \
+            '{
+              mode: $mode,
+              openclaw_repository: $openclaw_repository,
+              openclaw_ref: $openclaw_ref,
+              base_openclaw_repository: $base_openclaw_repository,
+              base_openclaw_ref: $base_openclaw_ref,
+              head_openclaw_repository: $head_openclaw_repository,
+              head_openclaw_ref: $head_openclaw_ref,
+              fixture_set: $fixture_set,
+              run_isolated_fixture: $run_isolated_fixture,
+              fixture: $fixture,
+              profile_runs: $profile_runs,
+              strict_contract: $strict_contract,
+              strict_perf: $strict_perf
+            }' > .github/openclaw-ref-request.json
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-
-      - run: node scripts/run-static-suite.mjs --openclaw ./openclaw --policy "${SUITE_POLICY}" --profile-runs "${PROFILE_RUNS}" --plugin-inspector-smoke
-      - name: Run runtime profile policy
-        run: node scripts/compare-runtime-profile.mjs ${{ inputs.strict_perf && '--strict' || '' }}
-      - run: node scripts/check-contract-coverage.mjs --openclaw ./openclaw
-      - name: Install OpenClaw lifecycle dependencies
-        run: |
-          corepack enable
-          corepack prepare "$(node -p "require('./openclaw/package.json').packageManager.split('+')[0]")" --activate
-          pnpm --dir openclaw install --frozen-lockfile --ignore-scripts
-
-      - name: Write report artifacts
-        if: always()
-        continue-on-error: true
-        run: |
-          node scripts/generate-report.mjs --openclaw ./openclaw
-          node scripts/capture-contracts.mjs --openclaw ./openclaw
-          node scripts/synthetic-probes.mjs --openclaw ./openclaw
-          node scripts/cold-import-readiness.mjs --openclaw ./openclaw
-          node scripts/workspace-plan.mjs --openclaw ./openclaw
-          node scripts/platform-probes.mjs --openclaw ./openclaw
-          node scripts/check-generated-surface-fixture.mjs --openclaw ./openclaw
-          node scripts/import-loop-profile.mjs --openclaw ./openclaw --runs "${PROFILE_RUNS}"
-          node scripts/profile-contract-runtime.mjs --openclaw ./openclaw --runs "${PROFILE_RUNS}"
-          node scripts/compare-runtime-profile.mjs ${{ inputs.strict_perf && '--strict' || '' }}
-          node scripts/check-ci-policy.mjs ${{ inputs.strict_contract && '--strict' || '' }}
-          node scripts/write-ci-summary.mjs --mode "${{ inputs.mode }}" --openclaw-label "${TARGET_REPOSITORY}@${TARGET_REF}" --github-step-summary
-
-      - name: Upload static compatibility reports
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: crabpot-openclaw-ref-static-reports
-          path: reports/
-          if-no-files-found: warn
-
-  ref-diff:
-    name: Compare base and head OpenClaw refs
-    runs-on: ubuntu-latest
-    if: ${{ inputs.mode == 'diff' || inputs.mode == 'full' }}
-    permissions:
-      contents: read
-    env:
-      PROFILE_RUNS: ${{ inputs.profile_runs }}
-    steps:
-      - name: Checkout Crabpot
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Checkout base OpenClaw
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.base_openclaw_repository }}
-          ref: ${{ inputs.base_openclaw_ref }}
-          path: openclaw-base
-
-      - name: Checkout head OpenClaw
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.head_openclaw_repository }}
-          ref: ${{ inputs.head_openclaw_ref }}
-          path: openclaw-head
-
-      - name: Show compared revisions
+      - name: Push ephemeral compatibility branch
         env:
-          BASE_LABEL: ${{ inputs.base_openclaw_repository }}@${{ inputs.base_openclaw_ref }}
-          HEAD_LABEL: ${{ inputs.head_openclaw_repository }}@${{ inputs.head_openclaw_ref }}
+          RUN_BRANCH: openclaw-ref-run/${{ github.run_id }}-${{ github.run_attempt }}
         run: |
-          echo "base=${BASE_LABEL}"
-          git -C openclaw-base rev-parse HEAD
-          echo "head=${HEAD_LABEL}"
-          git -C openclaw-head rev-parse HEAD
-          ln -s openclaw-head openclaw
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-
-      - run: node scripts/sync-fixtures.mjs --materialize --openclaw ./openclaw
-      - run: npm test
-      - name: Compare OpenClaw refs
-        env:
-          BASE_LABEL: ${{ inputs.base_openclaw_repository }}@${{ inputs.base_openclaw_ref }}
-          HEAD_LABEL: ${{ inputs.head_openclaw_repository }}@${{ inputs.head_openclaw_ref }}
-        run: |
-          node scripts/compare-openclaw-refs.mjs \
-            --base-openclaw ./openclaw-base \
-            --head-openclaw ./openclaw-head \
-            --base-label "${BASE_LABEL}" \
-            --head-label "${HEAD_LABEL}" \
-            ${{ inputs.strict_contract && '--strict' || '' }}
-      - name: Run runtime profile policy
-        run: |
-          node scripts/profile-contract-runtime.mjs --openclaw ./openclaw-head --runs "${PROFILE_RUNS}"
-          node scripts/compare-runtime-profile.mjs ${{ inputs.strict_perf && '--strict' || '' }}
-
-      - name: Write ref diff summary
-        if: always()
-        continue-on-error: true
-        env:
-          OPENCLAW_LABEL: ${{ inputs.base_openclaw_repository }}@${{ inputs.base_openclaw_ref }}..${{ inputs.head_openclaw_repository }}@${{ inputs.head_openclaw_ref }}
-        run: |
-          node scripts/profile-contract-runtime.mjs --openclaw ./openclaw-head --runs "${PROFILE_RUNS}"
-          node scripts/compare-runtime-profile.mjs ${{ inputs.strict_perf && '--strict' || '' }}
-          node scripts/check-ci-policy.mjs ${{ inputs.strict_contract && '--strict' || '' }}
-          node scripts/write-ci-summary.mjs --mode "${{ inputs.mode }}" --openclaw-label "${OPENCLAW_LABEL}" --github-step-summary
-
-      - name: Upload ref diff reports
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: crabpot-openclaw-ref-diff-reports
-          path: reports/
-          if-no-files-found: warn
-
-  fixture-plan:
-    name: Resolve isolated fixture set
-    runs-on: ubuntu-latest
-    if: ${{ inputs.mode == 'isolated' || inputs.mode == 'full' || (inputs.run_isolated_fixture && inputs.fixture != '') }}
-    outputs:
-      matrix: ${{ steps.resolve.outputs.matrix }}
-      count: ${{ steps.resolve.outputs.count }}
-      fixtures: ${{ steps.resolve.outputs.fixtures }}
-    permissions:
-      contents: read
-    env:
-      TARGET_REPOSITORY: ${{ (inputs.mode == 'full') && inputs.head_openclaw_repository || inputs.openclaw_repository }}
-      TARGET_REF: ${{ (inputs.mode == 'full') && inputs.head_openclaw_ref || inputs.openclaw_ref }}
-    steps:
-      - name: Checkout Crabpot
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Checkout target OpenClaw
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.TARGET_REPOSITORY }}
-          ref: ${{ env.TARGET_REF }}
-          path: openclaw
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-
-      - name: Resolve fixture matrix
-        id: resolve
-        env:
-          INPUT_FIXTURE_SET: ${{ inputs.fixture_set }}
-          INPUT_FIXTURE: ${{ inputs.fixture }}
-          INPUT_RUN_ISOLATED_FIXTURE: ${{ inputs.run_isolated_fixture }}
-        run: |
-          fixture_set="${INPUT_FIXTURE_SET}"
-          if [ "${INPUT_RUN_ISOLATED_FIXTURE}" = "true" ] && [ -n "${INPUT_FIXTURE}" ]; then
-            fixture_set="${INPUT_FIXTURE}"
-          fi
-          node scripts/resolve-fixture-set.mjs \
-            --fixture-set "${fixture_set}" \
-            --openclaw ./openclaw \
-            --allow-empty \
-            --github-output >> "$GITHUB_OUTPUT"
-
-      - name: Show selected fixtures
-        run: echo "fixtures=${{ steps.resolve.outputs.fixtures }}"
-
-  isolated-fixture:
-    name: Isolated fixture ${{ matrix.id }}
-    runs-on: ubuntu-latest
-    needs: fixture-plan
-    if: ${{ needs.fixture-plan.outputs.count != '0' }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.fixture-plan.outputs.matrix) }}
-    permissions:
-      contents: read
-    env:
-      TARGET_REPOSITORY: ${{ (inputs.mode == 'full') && inputs.head_openclaw_repository || inputs.openclaw_repository }}
-      TARGET_REF: ${{ (inputs.mode == 'full') && inputs.head_openclaw_ref || inputs.openclaw_ref }}
-    steps:
-      - name: Checkout Crabpot
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Checkout target OpenClaw
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.TARGET_REPOSITORY }}
-          ref: ${{ env.TARGET_REF }}
-          path: openclaw
-
-      - name: Show target revision
-        run: |
-          echo "repository=${TARGET_REPOSITORY}"
-          echo "ref=${TARGET_REF}"
-          git -C openclaw rev-parse HEAD
-          echo "fixture=${{ matrix.id }}"
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-
-      - name: Validate workspace plan
-        run: node scripts/workspace-plan.mjs --check --openclaw ./openclaw
-
-      - name: Execute fixture lane
-        id: execute
-        continue-on-error: true
-        env:
-          CRABPOT_EXECUTE_ISOLATED: "1"
-        run: npm run workspace:execute -- --fixture "${{ matrix.id }}" --allow-empty --openclaw ./openclaw
-
-      - name: Summarize execution artifacts
-        if: always()
-        continue-on-error: true
-        run: npm run execution:report
-
-      - name: Reconcile compatibility report with runtime evidence
-        if: always()
-        continue-on-error: true
-        run: node scripts/generate-report.mjs --openclaw ./openclaw --execution-results reports/crabpot-execution-results.json --fixture-set "${{ matrix.id }}"
-
-      - name: Run execution policy
-        id: policy
-        if: always()
-        continue-on-error: true
-        run: node scripts/check-ci-policy.mjs ${{ inputs.strict_contract && '--strict' || '' }}
-
-      - name: Write isolated summary
-        if: always()
-        continue-on-error: true
-        run: node scripts/write-ci-summary.mjs --mode "${{ inputs.mode }}" --openclaw-label "${TARGET_REPOSITORY}@${TARGET_REF}" --github-step-summary
-
-      - name: Upload isolated execution artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: crabpot-openclaw-ref-isolated-${{ matrix.id }}
-          path: |
-            .crabpot/results/
-            reports/crabpot-report.*
-            reports/crabpot-issues.*
-            reports/crabpot-execution-results.*
-            reports/crabpot-ci-policy.*
-            reports/crabpot-ci-summary.*
-          if-no-files-found: warn
-
-      - name: Fail if isolated execution failed
-        if: ${{ steps.execute.outcome == 'failure' || steps.policy.outcome == 'failure' }}
-        run: exit 1
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${RUN_BRANCH}"
+          git add .github/openclaw-ref-request.json
+          git commit -m "ci: stage OpenClaw ref compatibility request"
+          git push origin "HEAD:refs/heads/${RUN_BRANCH}"
+          {
+            echo "Compatibility execution was staged on \`${RUN_BRANCH}\`."
+            echo
+            echo "The branch-scoped run will delete the branch after completion."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/openclaw-ref-compat.yml
+++ b/.github/workflows/openclaw-ref-compat.yml
@@ -66,18 +66,29 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   dispatch:
     name: Stage branch-scoped compatibility run
     runs-on: ubuntu-latest
     steps:
+      - name: Create branch dispatch token
+        id: branch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: Iv23liOECG0slfuhz093
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Checkout trusted Crabpot source
         uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+          token: ${{ steps.branch-token.outputs.token }}
 
       - name: Write compatibility request
         env:

--- a/.github/workflows/openclaw-ref-compat.yml
+++ b/.github/workflows/openclaw-ref-compat.yml
@@ -69,27 +69,10 @@ permissions:
   contents: read
 
 jobs:
-  dispatch:
-    name: Stage branch-scoped compatibility run
+  request:
+    name: Queue branch-scoped compatibility run
     runs-on: ubuntu-latest
     steps:
-      - name: Create branch dispatch token
-        id: branch-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: Iv23liOECG0slfuhz093
-          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
-
-      - name: Checkout trusted Crabpot source
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 1
-          token: ${{ steps.branch-token.outputs.token }}
-
       - name: Write compatibility request
         env:
           MODE: ${{ inputs.mode }}
@@ -134,20 +117,15 @@ jobs:
               profile_runs: $profile_runs,
               strict_contract: $strict_contract,
               strict_perf: $strict_perf
-            }' > .github/openclaw-ref-request.json
+            }' > openclaw-ref-request.json
 
-      - name: Push ephemeral compatibility branch
-        env:
-          RUN_BRANCH: openclaw-ref-run/${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "${RUN_BRANCH}"
-          git add .github/openclaw-ref-request.json
-          git commit -m "ci: stage OpenClaw ref compatibility request"
-          git push origin "HEAD:refs/heads/${RUN_BRANCH}"
-          {
-            echo "Compatibility execution was staged on \`${RUN_BRANCH}\`."
-            echo
-            echo "The branch-scoped run will delete the branch after completion."
-          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload compatibility request
+        uses: actions/upload-artifact@v7
+        with:
+          name: openclaw-ref-compat-request
+          path: openclaw-ref-request.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Summarize queued request
+        run: echo "The trusted staging workflow will validate this request and start a branch-scoped run." >> "$GITHUB_STEP_SUMMARY"

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -6,8 +6,15 @@ async function readWorkflow(path) {
   return (await readFile(path, "utf8")).replace(/\r\n/g, "\n");
 }
 
+async function readOpenClawRefWorkflows() {
+  return [
+    await readWorkflow(".github/workflows/openclaw-ref-compat.yml"),
+    await readWorkflow(".github/workflows/openclaw-ref-compat-run.yml"),
+  ].join("\n");
+}
+
 test("manual OpenClaw ref workflow accepts branch tag or SHA inputs", async () => {
-  const workflow = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+  const workflow = await readOpenClawRefWorkflows();
 
   assert.match(workflow, /openclaw_repository:/);
   assert.match(workflow, /openclaw_ref:/);
@@ -16,14 +23,14 @@ test("manual OpenClaw ref workflow accepts branch tag or SHA inputs", async () =
   assert.match(workflow, /TARGET_REF:/);
   assert.match(workflow, /ref: \$\{\{ env\.TARGET_REF \}\}/);
   assert.match(workflow, /strict_contract:[\s\S]*default: true/);
-  assert.match(workflow, /SUITE_POLICY: \$\{\{ inputs\.strict_contract && 'release' \|\| 'dashboard' \}\}/);
+  assert.match(workflow, /SUITE_POLICY: \$\{\{ needs\.request\.outputs\.strict_contract == 'true' && 'release' \|\| 'dashboard' \}\}/);
   assert.match(workflow, /node scripts\/run-static-suite\.mjs --openclaw \.\/openclaw --policy "\$\{SUITE_POLICY\}"/);
   assert.match(workflow, /--plugin-inspector-smoke/);
   assert.match(workflow, /node scripts\/check-contract-coverage\.mjs --openclaw \.\/openclaw/);
 });
 
 test("manual OpenClaw ref workflow keeps isolated fixture execution opt-in", async () => {
-  const workflow = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+  const workflow = await readOpenClawRefWorkflows();
 
   assert.match(workflow, /run_isolated_fixture:/);
   assert.match(workflow, /fixture:/);
@@ -35,14 +42,31 @@ test("manual OpenClaw ref workflow keeps isolated fixture execution opt-in", asy
 });
 
 test("manual OpenClaw ref workflow has diff and profile modes", async () => {
-  const workflow = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+  const workflow = await readOpenClawRefWorkflows();
 
   assert.match(workflow, /mode:/);
   assert.match(workflow, /Compare base and head OpenClaw refs/);
   assert.match(workflow, /node scripts\/compare-openclaw-refs\.mjs/);
   assert.match(workflow, /node scripts\/compare-runtime-profile\.mjs/);
-  assert.match(workflow, /node scripts\/check-ci-policy\.mjs \$\{\{ inputs\.strict_contract && '--strict' \|\| '' \}\}/);
+  assert.match(workflow, /node scripts\/check-ci-policy\.mjs \$\{\{ needs\.request\.outputs\.strict_contract == 'true' && '--strict' \|\| '' \}\}/);
   assert.match(workflow, /node scripts\/write-ci-summary\.mjs/);
+});
+
+test("manual OpenClaw ref execution uses a branch-scoped cache boundary", async () => {
+  const dispatch = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+  const run = await readWorkflow(".github/workflows/openclaw-ref-compat-run.yml");
+  const check = await readWorkflow(".github/workflows/check.yml");
+
+  assert.match(dispatch, /workflow_dispatch:/);
+  assert.match(dispatch, /RUN_BRANCH: openclaw-ref-run\/\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/);
+  assert.match(dispatch, /\.github\/openclaw-ref-request\.json/);
+  assert.doesNotMatch(dispatch, /Checkout target OpenClaw/);
+  assert.doesNotMatch(dispatch, /npm (?:run|test)/);
+  assert.match(run, /push:\n\s+branches:\n\s+- "openclaw-ref-run\/\*\*"/);
+  assert.doesNotMatch(run, /workflow_dispatch:/);
+  assert.match(run, /name: Delete ephemeral compatibility branch/);
+  assert.match(run, /permissions:\n\s+contents: write[\s\S]*RUN_BRANCH: \$\{\{ github\.ref_name \}\}/);
+  assert.doesNotMatch(check, /workflow_dispatch:/);
 });
 
 test("default check workflow uploads policy and summary reports", async () => {
@@ -234,7 +258,7 @@ test("default check workflow resolves changed submodules into an isolated fixtur
 test("workflows use current action majors and dependency caches", async () => {
   const workflows = [
     await readWorkflow(".github/workflows/check.yml"),
-    await readWorkflow(".github/workflows/openclaw-ref-compat.yml"),
+    await readOpenClawRefWorkflows(),
     await readWorkflow(".github/workflows/dependabot-auto-merge.yml"),
     await readWorkflow(".github/workflows/openclaw-head-canary.yml"),
     await readWorkflow(".github/workflows/openclaw-pin-age.yml"),
@@ -299,28 +323,28 @@ test("crabbox hydrate validates the job key before writing state", async () => {
 });
 
 test("manual workflow enforces strict runtime profile policy before best-effort summaries", async () => {
-  const workflow = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+  const workflow = await readOpenClawRefWorkflows();
   const policySteps = [...workflow.matchAll(/- name: Run runtime profile policy\n(?<body>(?:        .*\n)+)/g)].map(
     (match) => match.groups.body,
   );
 
   assert.equal(policySteps.length, 2);
   for (const step of policySteps) {
-    assert.match(step, /node scripts\/compare-runtime-profile\.mjs \$\{\{ inputs\.strict_perf && '--strict' \|\| '' \}\}/);
+    assert.match(step, /node scripts\/compare-runtime-profile\.mjs \$\{\{ needs\.request\.outputs\.strict_perf == 'true' && '--strict' \|\| '' \}\}/);
     assert.doesNotMatch(step, /continue-on-error/);
   }
   assert.ok(policySteps.some((step) => step.includes("node scripts/profile-contract-runtime.mjs --openclaw ./openclaw-head")));
 });
 
 test("manual workflow writes OpenClaw lifecycle import profile artifacts", async () => {
-  const workflow = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+  const workflow = await readOpenClawRefWorkflows();
 
   assert.match(workflow, /pnpm --dir openclaw install --frozen-lockfile --ignore-scripts/);
   assert.match(workflow, /node scripts\/import-loop-profile\.mjs --openclaw \.\/openclaw --runs "\$\{PROFILE_RUNS\}"/);
 });
 
 test("manual workflow keeps isolated execution artifacts and failure policy wired", async () => {
-  const workflow = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+  const workflow = await readOpenClawRefWorkflows();
 
   assert.match(
     workflow,

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -9,6 +9,7 @@ async function readWorkflow(path) {
 async function readOpenClawRefWorkflows() {
   return [
     await readWorkflow(".github/workflows/openclaw-ref-compat.yml"),
+    await readWorkflow(".github/workflows/openclaw-ref-compat-stage.yml"),
     await readWorkflow(".github/workflows/openclaw-ref-compat-run.yml"),
   ].join("\n");
 }
@@ -54,17 +55,29 @@ test("manual OpenClaw ref workflow has diff and profile modes", async () => {
 
 test("manual OpenClaw ref execution uses a branch-scoped cache boundary", async () => {
   const dispatch = await readWorkflow(".github/workflows/openclaw-ref-compat.yml");
+  const stage = await readWorkflow(".github/workflows/openclaw-ref-compat-stage.yml");
   const run = await readWorkflow(".github/workflows/openclaw-ref-compat-run.yml");
   const check = await readWorkflow(".github/workflows/check.yml");
 
   assert.match(dispatch, /workflow_dispatch:/);
-  assert.match(dispatch, /actions\/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1/);
-  assert.match(dispatch, /permission-contents: write/);
-  assert.match(dispatch, /token: \$\{\{ steps\.branch-token\.outputs\.token \}\}/);
-  assert.match(dispatch, /RUN_BRANCH: openclaw-ref-run\/\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/);
-  assert.match(dispatch, /\.github\/openclaw-ref-request\.json/);
+  assert.match(dispatch, /actions\/upload-artifact@v7/);
+  assert.match(dispatch, /name: openclaw-ref-compat-request/);
+  assert.doesNotMatch(dispatch, /CLAWSWEEPER_APP_PRIVATE_KEY/);
+  assert.doesNotMatch(dispatch, /permission-contents: write/);
+  assert.doesNotMatch(dispatch, /actions\/create-github-app-token/);
   assert.doesNotMatch(dispatch, /Checkout target OpenClaw/);
   assert.doesNotMatch(dispatch, /npm (?:run|test)/);
+  assert.match(stage, /workflow_run:/);
+  assert.match(stage, /workflows: \["OpenClaw Ref Compatibility"\]/);
+  assert.match(stage, /github\.event\.workflow_run\.event == 'workflow_dispatch'/);
+  assert.match(stage, /github\.event\.workflow_run\.head_repository\.full_name == github\.repository/);
+  assert.match(stage, /gh run download "\$\{SOURCE_RUN_ID\}"/);
+  assert.match(stage, /actions\/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1/);
+  assert.match(stage, /permission-contents: write/);
+  assert.match(stage, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(stage, /token: \$\{\{ steps\.branch-token\.outputs\.token \}\}/);
+  assert.match(stage, /RUN_BRANCH: openclaw-ref-run\/\$\{\{ github\.event\.workflow_run\.id \}\}-\$\{\{ github\.event\.workflow_run\.run_attempt \}\}/);
+  assert.match(stage, /\.github\/openclaw-ref-request\.json/);
   assert.match(run, /push:\n\s+branches:\n\s+- "openclaw-ref-run\/\*\*"/);
   assert.doesNotMatch(run, /workflow_dispatch:/);
   assert.match(run, /name: Delete ephemeral compatibility branch/);

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -58,6 +58,9 @@ test("manual OpenClaw ref execution uses a branch-scoped cache boundary", async 
   const check = await readWorkflow(".github/workflows/check.yml");
 
   assert.match(dispatch, /workflow_dispatch:/);
+  assert.match(dispatch, /actions\/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1/);
+  assert.match(dispatch, /permission-contents: write/);
+  assert.match(dispatch, /token: \$\{\{ steps\.branch-token\.outputs\.token \}\}/);
   assert.match(dispatch, /RUN_BRANCH: openclaw-ref-run\/\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/);
   assert.match(dispatch, /\.github\/openclaw-ref-request\.json/);
   assert.doesNotMatch(dispatch, /Checkout target OpenClaw/);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where manually dispatched compatibility jobs could execute a selected OpenClaw checkout in the default branch cache scope, allowing that checkout to poison caches later consumed by trusted workflows.

## Why This Change Was Made

The manual workflow now writes its request as an artifact with read-only permissions and no secrets. A default-branch `workflow_run` broker validates that bounded request, mints the existing ClawSweeper App token, and pushes an ephemeral request branch. A push-only runner executes the compatibility jobs in that branch's cache scope, then a token-isolated cleanup job deletes the branch. The redundant manual trigger was also removed from the default check workflow.

## User Impact

Operators keep the same `OpenClaw Ref Compatibility` dispatch inputs. Execution appears as a trusted staging run followed by a branch-scoped workflow run, and the temporary branch is removed automatically.

## Evidence

- `node --test test/ci-workflows.test.mjs` (18 passed)
- `actionlint -config-file .github/actionlint.yaml .github/workflows/check.yml .github/workflows/openclaw-ref-compat.yml .github/workflows/openclaw-ref-compat-stage.yml .github/workflows/openclaw-ref-compat-run.yml`
- `git diff --check`
- Hosted pre-broker dispatcher proof created the ephemeral request branch:
  - https://github.com/openclaw/crabpot/actions/runs/32452429557
- Hosted branch-scoped runner completed the static compatibility job and token-isolated cleanup:
  - https://github.com/openclaw/crabpot/actions/runs/32452440355
- `openclaw-ref-run/32452429557-1` was absent from the live branch API after cleanup.
- Exact-head branch CodeQL reports no open alerts.
- Targets CodeQL alerts:
  - https://github.com/openclaw/crabpot/security/code-scanning/6
  - https://github.com/openclaw/crabpot/security/code-scanning/7
  - https://github.com/openclaw/crabpot/security/code-scanning/8

## Fixture Impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [ ] Changes contract or smoke logic
- [ ] Docs only

## Fixture Verification

- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] Strict fixture smoke, if submodules were materialized

## Notes

Fixture suites were not run locally because this is workflow-only. The final broker is intentionally default-branch-owned, so its complete three-stage hosted path can only be exercised after merge. Exact-head CodeQL and workflow CI run on the PR; live default-branch alert closure and the broker path will be verified at the squash SHA.
