### PR TITLE
fix(ci): use supported Node for current OpenClaw hosts

### DIFF
--- a/.github/workflows/openclaw-head-canary.yml
+++ b/.github/workflows/openclaw-head-canary.yml
@@ -40,7 +40,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: '24'
           cache: npm
           cache-dependency-path: |
             plugins/**/package-lock.json

--- a/.github/workflows/track-dashboard.yml
+++ b/.github/workflows/track-dashboard.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-node@v7
         if: ${{ steps.select.outputs.run == 'true' }}
         with:
-          node-version: 22
+          node-version: ${{ matrix.track == 'development' && '24' || '22' }}
           cache: npm
           cache-dependency-path: |
             plugins/**/package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.2 - Unreleased
 
+- Run the development dashboard and advisory HEAD canary on Node 24 for current OpenClaw hosts; keep the pinned Default Track and latest/beta dashboards on Node 22.
 - Refreshed compatible plugin fixture pins and npm locks, upgraded plugin-inspector to 0.3.21, and moved CI to current GitHub Actions.
 - Refreshed plugin fixtures and restored real OpenClaw lifecycle profiling against current diagnostics APIs.
 - Split CI into a required pinned OpenClaw Default Track, an advisory artifact-producing HEAD canary, and a 14-day pin-promotion SLA.


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch. GitHub's fork-collaboration flag does not apply.

</details>

## What Problem This Solves

Resolves a problem where the development dashboard and advisory HEAD canary select current OpenClaw hosts but run them on unsupported Node 22.

## Why This Change Was Made

Use Node 24 only for those current-host lanes. Preserve Node 22 for the pinned Default Track and latest/beta dashboards, the default host pin, arbitrary-ref workflows, action versions, caching, triggers, profile fallbacks, advisory status, failure policy, and publishing.

This is a runtime prerequisite, not a complete dashboard repair. No source, helper, dependency, configuration, or timeout changes.

## User Impact

Current-host jobs select the supported Node major. Existing fixture and inspector failures remain visible, as does the separately observed lifecycle harness mismatch below.

## Evidence

- Exact reproduction host: `c667fa4cd0928f4ce02e394a8544e08957af170d`, engines `>=24.16.0 <25 || >=26.1.0`.
- Real `semver` under Node `22.23.2`: unsupported, exit 1. Under Node `24.20.0`: supported, exit 0.
- Unchanged default host `5570c5ffac86acb74979c7314da6f3364781985a` accepts Node `22.23.2`.
- Frozen, ignore-scripts dependency installation passed with the historical host's declared pnpm `12.3.4` on Node `24.20.0`; no tracked host changes.
- Existing `node --test test/ci-workflows.test.mjs`: 18/18 passed on each of Node `22.23.2` and `24.20.0`.
- `actionlint .github/workflows/track-dashboard.yml .github/workflows/openclaw-head-canary.yml` and `git diff --check` passed.
- Credential-free disposable containers, non-root, no host mounts, dropped capabilities, no new privileges, bounded CPU/memory/processes. No live services or provider credentials.
- Actual unchanged `import-loop-profile.mjs --openclaw ../openclaw --runs 3` still fails: three failed samples, three failed baseline captures, `openClawLifecycleCount: 0`. Direct capture stderr identifies `TypeError: clearActivatedPluginRuntimeState is not a function` at `scripts/run-openclaw-lifecycle-capture.mjs:101`; the exact host's `src/plugins/loader.ts` no longer exports it. This is separate unchanged harness API drift, not repaired by an engine change.
- Independent Sol/high diff review: scoped-clean through P2, no findings. Exact-head hosted CI remains a separate landing gate.

`setup-node@v7` may choose a matching cached patch because `check-latest` remains false. Before landing, record the actual Node 24 patch for every canary OS and validate it against the exact shared host manifest. An unsupported patch requires scope review, not silently adding `check-latest`. The development workflow checks out `main`; its changed-runtime observation requires the later authorized scheduled run, not a manual candidate dispatch.

## Fixture Impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [ ] Changes contract or smoke logic
- [ ] Docs only

Workflow-only runtime selection; no fixture changes. Does not replace or supersede the separate QQbot work: https://github.com/openclaw/crabpot/pull/287.

## Fixture Verification

- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] Strict fixture smoke, if submodules were materialized

The existing workflow tests and actual dependency/lifecycle flow were scoped proof. Full native fixture coverage remains the unchanged exact-head required Default Track CI gate, not claimed as a local rerun.

## Notes

- Workflow LOC: +2/-2. JavaScript, tests, dependencies, and generated artifacts: zero. Changelog: +1.
- Draft only. No merge or manual dispatch. Strict/up-to-date `Default Track (pinned OpenClaw)` remains required, with current ClawSweeper Rank-up dispositions and parent landing approval.
- Existing automatic README/report publication is unchanged. No release, tag, npm publication, dependency adoption, or live-service changes.
- No dashboard-restored, successful host activation, provider-auth, Codex protocol, or performance-improvement claim.
