### PR TITLE
chore: adopt plugin-inspector 0.3.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.2.2 - Unreleased
 
 - Failed npm fixture packs now stop materialization and dependent checks after collecting availability evidence, including when report writing is disabled; successful pinned fallbacks remain supported. Availability reports now label the resolved CLI or environment fixture selection.
-- Adopted the inspector source repair for credential-free model-auth registration capture; published-package smoke remains on the older 0.3.24 release.
+- Adopted inspector 0.3.25 in both source and published-package modes for bounded capture/probes, serial service lifecycle probes, CommonJS SDK mocks, Gateway response validation, and credential-free model-auth binding.
 - Removed the obsolete bundled QQ Bot source fixture that blocked development dashboard materialization after OpenClaw externalized the plugin; retained the Tencent QQbot git fixture and its channel/tool coverage.
 - Restored native lifecycle profiling through root registry activation and rejected malformed phase timings.
 - Run the development dashboard and advisory HEAD canary on Node 24 for current OpenClaw hosts; keep the pinned Default Track and latest/beta dashboards on Node 22.

--- a/docs/inspector-plan.md
+++ b/docs/inspector-plan.md
@@ -93,7 +93,7 @@ npm run plugin-inspector:smoke
 ```
 
 The smoke writes ignored artifacts under `.crabpot/plugin-inspector-smoke/`.
-By default the smoke runs the published `@openclaw/plugin-inspector@0.3.24`
+By default the smoke runs the published `@openclaw/plugin-inspector@0.3.25`
 package through `npm exec`. For local plugin-inspector development, set
 `CRABPOT_PLUGIN_INSPECTOR_CLI=source` to run the sibling or pinned source
 checkout instead. Set `CRABPOT_PLUGIN_INSPECTOR_DIR=/path/to/candidate` to select
@@ -101,11 +101,12 @@ an exact candidate checkout before its npm release. Set
 `CRABPOT_PLUGIN_INSPECTOR_BIN=/path/to/plugin-inspector`
 to test an arbitrary CLI binary.
 
-The pinned source and published package recognize compiled CommonJS channel
+The pinned 0.3.25 source and published package recognize compiled CommonJS channel
 factory calls and classify widget presenters as metadata-only synthetic probes.
-Only the pinned source includes credential-free model-auth binding during
-registration capture. Published npm `0.3.24` does not include that repair;
-package-mode smoke is not proof of source/package parity.
+Both include credential-free model-auth binding,
+bounded capture and synthetic probes, serial service lifecycle probes,
+CommonJS SDK mock capture, and Gateway response validation.
+Run source-mode and package-mode smoke separately when validating a new release.
 
 Current migration state: `scripts/inspect-fixtures.mjs` delegates static source,
 manifest, and package inspection to `plugin-inspector` while preserving

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -135,15 +135,17 @@ npm run profile -- --check
 node scripts/check-contract-coverage.mjs --openclaw ../openclaw
 ```
 
-Source-backed reports and registration capture use the landed inspector repair
-for credential-free model-auth binding. `npm run plugin-inspector:smoke` still
-uses the older published `@openclaw/plugin-inspector@0.3.24` package by default;
-that package does not contain the repair. Use
+Source-backed reports and registration capture use inspector 0.3.25,
+including bounded capture/probes, CommonJS SDK mocks, serial service lifecycle
+probes, and Gateway response validation. `npm run plugin-inspector:smoke`
+uses the published `@openclaw/plugin-inspector@0.3.25` package by default.
+Use
 `CRABPOT_PLUGIN_INSPECTOR_CLI=source npm run plugin-inspector:smoke` only when
 validating local inspector source changes. Set `CRABPOT_PLUGIN_INSPECTOR_DIR`
 to the candidate checkout to avoid selecting a different sibling checkout.
-Keep the published package pin unchanged until the candidate is on npm, then
-update it and run the package-mode smoke separately.
+For a published-package check, unset `CRABPOT_PLUGIN_INSPECTOR_BIN`,
+`CRABPOT_PLUGIN_INSPECTOR_CLI`, and `CRABPOT_PLUGIN_INSPECTOR_DIR`, and use a
+fresh `npm_config_cache`. Run this separately from the source-mode smoke.
 The npm smoke forwards `--check`, so reported compatibility breakages produce
 a failing exit status. Direct wrapper calls without `--check` only write reports.
 

--- a/scripts/plugin-inspector-source.mjs
+++ b/scripts/plugin-inspector-source.mjs
@@ -4,8 +4,8 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./manifest-lib.mjs";
 
-export const pluginInspectorRef = "84ede904fd6e766a9fc4de002f39af87d90c1916";
-export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.24";
+export const pluginInspectorRef = "2e21b3b48aa06fea30b08202f4c6be13c1f3216a";
+export const pluginInspectorPackage = "@openclaw/plugin-inspector@0.3.25";
 
 export async function loadPluginInspector() {
   const publicApi = await import(pathToFileURL(resolvePluginInspectorSourcePath()).href);

--- a/test/plugin-inspector-source.test.mjs
+++ b/test/plugin-inspector-source.test.mjs
@@ -13,7 +13,7 @@ import {
 } from "../scripts/plugin-inspector-source.mjs";
 
 test("plugin inspector source pin requires an exact prepared checkout", (t) => {
-  assert.equal(pluginInspectorRef, "84ede904fd6e766a9fc4de002f39af87d90c1916");
+  assert.equal(pluginInspectorRef, "2e21b3b48aa06fea30b08202f4c6be13c1f3216a");
 
   const checkoutDir = mkdtempSync(path.join(os.tmpdir(), "crabpot-plugin-inspector-"));
   t.after(() => rmSync(checkoutDir, { force: true, recursive: true }));
@@ -48,7 +48,7 @@ test("plugin inspector smoke defaults to the published npm package", () => {
     const invocation = resolvePluginInspectorCliInvocation();
 
     assert.equal(invocation.command, "npm");
-    assert.equal(pluginInspectorPackage, "@openclaw/plugin-inspector@0.3.24");
+    assert.equal(pluginInspectorPackage, "@openclaw/plugin-inspector@0.3.25");
     assert.deepEqual(invocation.args, ["exec", "--yes", "--package", pluginInspectorPackage, "--", "plugin-inspector"]);
     assert.equal(invocation.shell, process.platform === "win32");
   });


### PR DESCRIPTION
## What Problem This Solves

Crabpot's default packaged inspector remained on 0.3.24, while its source pin lacked the completed 0.3.25 lifecycle, timeout, CommonJS capture, and Gateway validation repairs.

## Why This Change Was Made

Pins both source and published-package modes to the verified 0.3.25 release, updates their existing test guards, and brings the two operational docs and changelog into agreement. No fixture, host, runtime logic, workflow, or report expectation changes.

Related release: https://github.com/openclaw/plugin-inspector/pull/75

## User Impact

Default package-mode smoke and pinned source consumers now use the released inspector repairs. Development overrides remain available; the docs explain how to keep source-mode and fresh-cache published-mode checks distinct.

## Evidence

- Frozen follow-through head: `39d79acfe352aee270fb6186e1604d84a705e32f`, based on Crabpot main `6219f185358ff03219bf2953c6b114ffaee9a78a`. Five files, 19 additions and 16 deletions.
- Inspector source pin: `2e21b3b48aa06fea30b08202f4c6be13c1f3216a`, annotated release https://github.com/openclaw/plugin-inspector/releases/tag/v0.3.25. Existing tag-push trusted-publishing workflow passed at that exact SHA: https://github.com/openclaw/plugin-inspector/actions/runs/34380426028.
- Registry `gitHead`, latest tag, integrity, signatures, and provenance verified. The provenance subject binds the package digest to the exact source SHA, release tag, workflow, and run. Fresh registry installation with scripts disabled passed all 19 public exports, root API and CLI checks, and byte comparison of all 59 package files against the release commit.
- Published tarball SHA-256: `d29d54c51d729f2162473a242e1a0d00e0c5ba75eb5b2b67b2aa2aed40dc6151`, identical to the reviewed candidate.
- Actual `npm run plugin-inspector:smoke` in default published mode passed all 59 unchanged fixtures with zero breakages. `CRABPOT_PLUGIN_INSPECTOR_BIN`, `CRABPOT_PLUGIN_INSPECTOR_CLI`, and `CRABPOT_PLUGIN_INSPECTOR_DIR` were unset; npm used a fresh cache and disabled lifecycle scripts.
- Source, installed candidate tarball, and published inventory reports match apart from timestamps. Source proof is bound to the landed release SHA by exact candidate/release tree equivalence and all 59 package-file comparisons.
- Additional published compatibility report against the unchanged pinned OpenClaw host `5570c5ffac86acb74979c7314da6f3364781985a` also matches source/packed reports: 59 fixtures, zero fixture breakages, 384 findings including nine live/P0 findings. One published 0.3.24 baseline on those exact inputs confirms all 384 issues are unchanged. The host's re-exported compat registry remains a pre-existing parser limitation, not hidden by an expectation change.
- Acquisition preserved all 30 gitlink pins and the exact recorded versions of 27 npm fixtures, with scripts disabled, archive containment validation, and registry-derived metadata. Matrix and Mattermost retained native source-pack semantics from the pinned host. No external plugin code was imported or built.
- Strict `release:crabpot --expected-ref 2e21b3b48aa06fea30b08202f4c6be13c1f3216a --expected-version 0.3.25 --published` passed. This checklist does not execute smokes; the actual runs are recorded separately above.
- Final pin/CLI tests: 5 passed. Earlier focused report, cold-import, and synthetic consumer tests: 20 passed without expectation changes. Final five-file P2 review: scoped-clean. `git diff --check` passed.
- Exact-head Check passed on `39d79acfe352aee270fb6186e1604d84a705e32f`: Linux, macOS, Windows, container, fixture-security scope check, and required `Default Track (pinned OpenClaw)` aggregate are green: https://github.com/openclaw/crabpot/actions/runs/34380916198. CodeQL passed at the same head: https://github.com/openclaw/crabpot/actions/runs/34380914227.

## Fixture Impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [ ] Changes contract or smoke logic
- [ ] Docs only

Dependency source/package pins, matching test guards, and release documentation only. All fixture versions, configuration, and expectations remain unchanged.

## Fixture Verification

- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] Strict fixture smoke, if submodules were materialized

The full materializing suite was not rerun locally for this pin/docs delta. Actual inspector source/packed/published inventory and pinned-host report checks and focused consumer tests are listed above. Native exact-head PR CI subsequently passed on all four required static lanes.

## Notes

No external runtime services or credentials were used. Static report success is not a claim that the pinned host is free of compatibility findings or that external plugins executed successfully. Existing maintainer drafts and unrelated fixture-containment work are untouched. The source owner accepted the final five-file diff, publication binding, actual smokes, P2 review, and exact-head required CI, and granted the serial merge slot for this head. The separate advisory HEAD canary is not a required gate; its Windows report finalization was still running when merge clearance was granted.
