### PR TITLE
chore: add temporary Windows startup diagnostics

### DIFF
--- a/scripts/owned-command-windows.cs
+++ b/scripts/owned-command-windows.cs
@@ -10,6 +10,46 @@ using System.Threading;
 // admits the root atomically; the child never inherits the controller pipe.
 public static class CrabpotCommandJob
 {
+    // Temporary issue305 receipt file; independent of the Worker/control pipe.
+    sealed class StartupTrace
+    {
+        readonly string file, id;
+        readonly Stopwatch clock = Stopwatch.StartNew();
+        int sequence, bytes;
+
+        public StartupTrace(string directory, string attemptId)
+        {
+            try
+            {
+                Guid parsed;
+                if (String.IsNullOrEmpty(directory) || !Guid.TryParse(attemptId, out parsed)) return;
+                file = Path.Combine(directory, "native.jsonl");
+                id = parsed.ToString("D");
+            }
+            catch {}
+        }
+
+        public void Write(string name, uint pid = 0, bool extinct = false)
+        {
+            if (file == null || sequence >= 32) return;
+            try
+            {
+                // Names are fixed literals and id is a parsed Guid; no payload strings.
+                string line = String.Format(System.Globalization.CultureInfo.InvariantCulture,
+                    "{{\"id\":\"{0}\",\"producer\":\"native\",\"sequence\":{1},\"event\":\"{2}\"," +
+                    "\"unixMs\":{3},\"elapsedMs\":{4},\"clock\":\"Stopwatch.ElapsedMilliseconds\"," +
+                    "\"childPid\":{5},\"previouslyConfirmed\":{6}}}\n",
+                    id, ++sequence, name, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    clock.ElapsedMilliseconds, pid, extinct ? "true" : "false");
+                int length = Encoding.UTF8.GetByteCount(line);
+                if (length > 2048 || bytes + length > 65536) return;
+                bytes += length;
+                File.AppendAllText(file, line, new UTF8Encoding(false));
+            }
+            catch {}
+        }
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     struct BasicLimits
     {
@@ -121,8 +161,11 @@ public static class CrabpotCommandJob
 
     public static void Run(string application, string commandLine, string cwd, string environment,
         int timeout, int cleanup, CancellationTokenSource ownerLost,
-        CancellationTokenRegistration bootstrapKill, StreamWriter receipt)
+        CancellationTokenRegistration bootstrapKill, StreamWriter receipt,
+        string diagnosticDirectory = null, string diagnosticId = null)
     {
+        StartupTrace trace = new StartupTrace(diagnosticDirectory, diagnosticId);
+        trace.Write("native-entered");
         if (IntPtr.Size != 8 || Marshal.SizeOf(typeof(StartupInfoEx)) != 112 ||
             Marshal.SizeOf(typeof(ExtendedLimits)) != 144 || Marshal.SizeOf(typeof(Accounting)) != 48)
             throw new PlatformNotSupportedException("Windows Job ownership requires a 64-bit Windows runtime");
@@ -175,13 +218,17 @@ public static class CrabpotCommandJob
             startup.Startup.Stderr = inherited[2];
             startup.Attributes = attributes;
             environmentBlock = Marshal.StringToHGlobalUni(environment);
+            trace.Write("create-process-precheck");
             if (ownerLost.IsCancellationRequested)
                 throw new IOException("command owner disconnected before admission");
             Check(CreateProcessW(application, new StringBuilder(commandLine), IntPtr.Zero,
                 IntPtr.Zero, true, 0x08080400, environmentBlock, cwd, ref startup, out child),
                 "CreateProcessW(JOB_LIST)");
             created = true;
+            trace.Write("create-process-succeeded", child.ProcessId);
+            trace.Write("ready-write-begin", child.ProcessId);
             receipt.WriteLine("READY " + child.ProcessId);
+            trace.Write("ready-write-end", child.ProcessId);
             // Backing HANDLE arrays stay alive through CreateProcess and attribute deletion.
             DeleteProcThreadAttributeList(attributes);
             initialized = false;
@@ -220,12 +267,21 @@ public static class CrabpotCommandJob
             }
             if (timedOut) receipt.WriteLine("TIMEOUT");
             receipt.WriteLine("CLOSED");
+            trace.Write("closed-write-end", child.ProcessId, extinct);
         }
         finally
         {
+            trace.Write("native-cleanup-entered", child.ProcessId, extinct);
             // Owner loss or receipt failure still performs bounded explicit cleanup.
             // KILL_ON_JOB_CLOSE is only the last fallback, never a success receipt.
-            try { if (created && !extinct) TerminateAndObserve(job, cleanup); }
+            try
+            {
+                if (created && !extinct)
+                {
+                    TerminateAndObserve(job, cleanup);
+                    trace.Write("finally-job-extinction-observed", child.ProcessId, extinct);
+                }
+            }
             finally
             {
                 if (initialized) DeleteProcThreadAttributeList(attributes);
@@ -237,6 +293,7 @@ public static class CrabpotCommandJob
                 if (handles != IntPtr.Zero) Marshal.FreeHGlobal(handles);
                 if (jobList != IntPtr.Zero) Marshal.FreeHGlobal(jobList);
                 if (environmentBlock != IntPtr.Zero) Marshal.FreeHGlobal(environmentBlock);
+                trace.Write("native-cleanup-ended", child.ProcessId, extinct);
             }
         }
     }

--- a/scripts/owned-command-windows.ps1
+++ b/scripts/owned-command-windows.ps1
@@ -1,19 +1,48 @@
-param([string]$PipeName)
+param([string]$PipeName, [string]$DiagnosticDirectory, [string]$DiagnosticId)
 $ErrorActionPreference = "Stop"
+$startupSequence = 0
+$startupBytes = 0
+$startupClock = [System.Diagnostics.Stopwatch]::StartNew()
+$startupUtf8 = [System.Text.UTF8Encoding]::new($false)
+function Write-StartupTrace([string]$Event, [hashtable]$Fields = @{}) {
+    if (-not $DiagnosticDirectory -or $script:startupSequence -ge 32) { return }
+    try {
+        $script:startupSequence += 1
+        $record = [ordered]@{
+            id = $DiagnosticId; producer = "powershell"; sequence = $script:startupSequence
+            event = $Event; unixMs = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+            elapsedMs = $startupClock.ElapsedMilliseconds; clock = "Stopwatch.ElapsedMilliseconds"
+        }
+        foreach ($key in $Fields.Keys) { $record[$key] = $Fields[$key] }
+        $line = ($record | ConvertTo-Json -Compress -Depth 3) + "`n"
+        $length = $startupUtf8.GetByteCount($line)
+        if ($length -gt 2048 -or $script:startupBytes + $length -gt 65536) { return }
+        $script:startupBytes += $length
+        [System.IO.File]::AppendAllText(
+            (Join-Path $DiagnosticDirectory "powershell.jsonl"), $line, $startupUtf8)
+    } catch {}
+}
+Write-StartupTrace "helper-entered" @{ helperPid = $PID }
 $pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
     ".", $PipeName, [System.IO.Pipes.PipeDirection]::InOut, [System.IO.Pipes.PipeOptions]::Asynchronous)
 $reader = $null
 $writer = $null
 $bootstrapKill = $null
 try {
+    Write-StartupTrace "connect-begin"
     $pipe.Connect(5000)
+    Write-StartupTrace "connect-end"
     $utf8 = [System.Text.UTF8Encoding]::new($false)
     $reader = [System.IO.StreamReader]::new($pipe, $utf8, $false, 4096, $true)
     $writer = [System.IO.StreamWriter]::new($pipe, $utf8, 4096, $true)
     $writer.AutoFlush = $true
+    Write-StartupTrace "read-begin"
     $line = $reader.ReadLine()
+    Write-StartupTrace "read-end" @{ eof = ($null -eq $line) }
     if ($null -eq $line) { exit 1 }
+    Write-StartupTrace "parse-begin"
     $request = $line | ConvertFrom-Json
+    Write-StartupTrace "parse-end"
     # Direct .NET delegates do not depend on the PowerShell runspace while Add-Type blocks.
     $ownerLost = [System.Threading.CancellationTokenSource]::new()
     $killSelf = [System.Delegate]::CreateDelegate([System.Action], [System.Diagnostics.Process]::GetCurrentProcess(), "Kill")
@@ -21,6 +50,7 @@ try {
     $bootstrapKill = $ownerLost.Token.Register($killSelf)
     $ownerRead = $reader.ReadLineAsync()
     $ownerRead.ConfigureAwait($false).GetAwaiter().OnCompleted($cancelOwner)
+    Write-StartupTrace "owner-monitor-installed"
     # CodeDOM starts csc.exe. Contain this dedicated helper before compiling the
     # command owner; emitting these five fixed declarations starts no compiler.
     if ([IntPtr]::Size -ne 8) { throw "Windows Job ownership requires a 64-bit Windows runtime" }
@@ -73,16 +103,21 @@ try {
                 [System.Runtime.InteropServices.Marshal]::GetLastWin32Error(), "AssignProcessToJobObject(bootstrap)")
         }
         $assigned = $true
+        Write-StartupTrace "bootstrap-job-assigned"
     } finally {
         if ($limits -ne [IntPtr]::Zero) { [System.Runtime.InteropServices.Marshal]::FreeHGlobal($limits) }
         if (-not $assigned) { [void]$native::CloseHandle($bootstrapJob) }
     }
     # Keep the non-inheritable Job handle for this process's lifetime. Helper
     # death closes it and kills compiler descendants; that is not a success receipt.
+    Write-StartupTrace "compile-begin"
     Add-Type -Path (Join-Path $PSScriptRoot "owned-command-windows.cs")
+    Write-StartupTrace "compile-end"
     [CrabpotCommandJob]::Run(
         $request.application, $request.commandLine, $request.cwd, $request.environment,
-        [int]$request.timeout, [int]$request.cleanup, $ownerLost, $bootstrapKill, $writer)
+        [int]$request.timeout, [int]$request.cleanup, $ownerLost, $bootstrapKill, $writer,
+        $DiagnosticDirectory, $DiagnosticId)
+    Write-StartupTrace "native-returned"
 } catch {
     if ($null -ne $writer) {
         $failure = $_.Exception
@@ -94,13 +129,18 @@ try {
             $detail.nativeCode = $failure.NativeErrorCode
             $detail.operation = $failure.Message
         }
+        Write-StartupTrace "helper-error" @{
+            nativeCode = $(if ($failure -is [System.ComponentModel.Win32Exception]) { $failure.NativeErrorCode } else { $null })
+        }
         $encoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(($detail | ConvertTo-Json -Compress)))
         try { $writer.WriteLine("ERROR " + $encoded) } catch {}
     }
     exit 1
 } finally {
+    Write-StartupTrace "helper-finally-entered"
     if ($null -ne $bootstrapKill) { $bootstrapKill.Dispose() }
     if ($null -ne $writer) { $writer.Dispose() }
     if ($null -ne $reader) { $reader.Dispose() }
     $pipe.Dispose()
+    Write-StartupTrace "helper-control-disposed"
 }

--- a/scripts/owned-command.mjs
+++ b/scripts/owned-command.mjs
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { appendFileSync, mkdirSync, writeSync } from "node:fs";
 import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -13,6 +14,130 @@ const startupMs = 10_000;
 const cleanupMs = 2_000;
 const termGraceMs = 200;
 const defaultMaxBuffer = 1024 * 1024;
+
+// Temporary issue305 diagnostics. Each producer owns its file, independently of
+// the command control pipe and Worker lifetime. No diagnostic is an authority receipt.
+const diagnosticRecordLimit = 32;
+const diagnosticByteLimit = diagnosticRecordLimit * 2048;
+let diagnosticSelected = false;
+
+function startupDiagnostic(command, args, options) {
+  if (process.platform !== "win32" || diagnosticSelected || command !== "git" || args[0] !== "init" ||
+      typeof args[1] !== "string") return null;
+  const cwd = fileURLOrPath(options.cwd ?? process.cwd());
+  if (path.dirname(args[1]) !== path.join(cwd, ".crabpot", "plugin-inspector") ||
+      !/^[a-f0-9]{40}$/.test(path.basename(args[1]))) return null;
+  diagnosticSelected = true;
+  const root = path.join(cwd, "reports", "crabpot-startup-305");
+  try {
+    mkdirSync(root, { recursive: true });
+    for (let attempt = 1; attempt <= 4; attempt += 1) {
+      const directory = path.join(root, `attempt-${attempt}`);
+      try { mkdirSync(directory); } catch (error) {
+        if (error.code === "EEXIST") continue;
+        throw error;
+      }
+      const entry = path.basename(process.argv[1] ?? "");
+      return {
+        root, directory, attempt, id: randomUUID(),
+        entry: entry === "capture-contracts.test.mjs" ? "cold-contract-test"
+          : /^(generate-report|capture-contracts|synthetic-probes|cold-import-readiness|workspace-plan|platform-probes|check-generated-surface-fixture|import-loop-profile|profile-contract-runtime)\.mjs$/.test(entry)
+            ? "later-report" : "other",
+      };
+    }
+  } catch {}
+  try { writeSync(2, "crabpot-startup-305: diagnostic storage unavailable or attempt limit reached\n"); } catch {}
+  return null;
+}
+
+function startupTrace(context, producer) {
+  let sequence = 0;
+  let bytes = 0;
+  const started = performance.now();
+  return (event, fields = {}) => {
+    if (!context || sequence >= diagnosticRecordLimit) return;
+    try {
+      const line = `${JSON.stringify({
+        id: context.id, producer, sequence: ++sequence, event,
+        unixMs: Date.now(), elapsedMs: Math.round(performance.now() - started),
+        clock: "performance.now", ...fields,
+      })}\n`;
+      const length = Buffer.byteLength(line);
+      if (length > 2048 || bytes + length > diagnosticByteLimit) return;
+      bytes += length;
+      appendFileSync(path.join(context.directory, `${producer}.jsonl`), line, { encoding: "utf8", mode: 0o600 });
+    } catch {}
+  };
+}
+
+function startupError(error, includeCause = true) {
+  if (!error) return null;
+  const token = (value) => typeof value === "string" && /^[A-Z][A-Z0-9_]{0,63}$/.test(value) ? value : null;
+  const message = String(error.message ?? "");
+  const knownMessage = /^(?:command (?:supervisor (?:startup timed out|exceeded its deadline|terminal cleanup receipt was not observed)|owner stopped|output exceeded maxBuffer|timed out after \d+ms)|Windows (?:command adapter startup timed out|Job (?:cleanup receipt missing|extinction receipt was not observed)|helper (?:closure was not observed|did not close after forced termination)|adapter (?:exited before command request|exited without Job extinction receipt|failed \((?:\d+|SIG[A-Z]+)\))))(?:; command cleanup was not confirmed)?$/;
+  return {
+    code: token(error.code), errno: Number.isSafeInteger(error.errno) ? error.errno : null,
+    nativeCode: Number.isSafeInteger(error.nativeCode) ? error.nativeCode : null,
+    operation: typeof error.operation === "string" &&
+      /^(?:CreateProcessW\(JOB_LIST\)|CreateJobObjectW|SetInformationJobObject|AssignProcessToJobObject|HANDLE_LIST|JOB_LIST|WaitForSingleObject)(?:\(bootstrap\))?$/.test(error.operation)
+      ? error.operation : null,
+    message: knownMessage.test(message) ? message.slice(0, 192) : "[redacted]",
+    ...(includeCause && error.cause ? { cause: startupError(error.cause, false) } : {}),
+  };
+}
+
+function startupResult(result) {
+  const bytes = (value) => value == null ? null : typeof value === "string" ? Buffer.byteLength(value) : value.byteLength;
+  return {
+    status: result?.status ?? null, signal: result?.signal ?? null, childPid: result?.pid ?? null,
+    error: startupError(result?.error), cleanupError: startupError(result?.cleanupError),
+    stdoutBytes: bytes(result?.stdout), stderrBytes: bytes(result?.stderr),
+  };
+}
+
+function summarizeStartup(context) {
+  if (!context) return;
+  try {
+    const original = {};
+    for (const producer of ["parent", "worker", "powershell", "native"]) {
+      const file = path.join(context.root, "attempt-1", `${producer}.jsonl`);
+      try {
+        if (statSync(file).size > diagnosticByteLimit) {
+          original[producer] = { invalid: "byte-limit" };
+          continue;
+        }
+        const lines = readFileSync(file, "utf8").split("\n").filter(Boolean);
+        const records = lines.slice(0, diagnosticRecordLimit).flatMap((line) => {
+          try { return [JSON.parse(line)]; } catch { return []; }
+        });
+        const last = records.at(-1);
+        original[producer] = {
+          records: records.length,
+          last: /^[a-z-]{1,64}$/.test(last?.event ?? "") ? last.event : null,
+          sequence: Number.isSafeInteger(last?.sequence) ? last.sequence : null,
+          unixMs: Number.isSafeInteger(last?.unixMs) ? last.unixMs : null,
+        };
+        if (producer === "parent") {
+          const entry = records[0]?.entry;
+          const final = records.find((record) => record.event === "parent-finalized");
+          original[producer].entry = ["cold-contract-test", "later-report", "other"].includes(entry) ? entry : null;
+          original[producer].result = final ? {
+            error: startupError(final.result?.error), cleanupError: startupError(final.result?.cleanupError),
+            status: Number.isSafeInteger(final.result?.status) ? final.result.status : null,
+            readyConsumed: final.readyConsumed === true, terminalReceipt: final.terminalReceipt === true,
+          } : null;
+        }
+      } catch { original[producer] = { records: 0, missingOrUnreadable: true }; }
+    }
+    const line = `crabpot-startup-305 ${JSON.stringify({
+      attempt: context.attempt, id: context.id, snapshotUnixMs: Date.now(), original,
+    })}\n`;
+    if (Buffer.byteLength(line) <= 8192) writeSync(2, line);
+  } catch {}
+}
+
+const workerTrace = startupTrace(workerData?.startupDiagnostic, "worker");
+if (workerData?.ownedCommand) workerTrace("worker-entered");
 
 export function configuredTimeoutMs(name, fallback) {
   const raw = process.env[name];
@@ -34,12 +159,17 @@ export function runOwnedCommand(command, args, options = {}) {
   if (!Number.isSafeInteger(maxBuffer) || maxBuffer < 1) {
     throw new RangeError("command maxBuffer must be a finite positive integer");
   }
+  const diagnostic = startupDiagnostic(command, args, options);
+  const trace = startupTrace(diagnostic, "parent");
+  let terminationRequested = false;
+  trace("parent-entered", { entry: diagnostic?.entry, node: process.version, startupMs, cleanupMs, timeoutMs: timeout });
   const shared = new Int32Array(new SharedArrayBuffer(16));
   const { port1, port2 } = new MessageChannel();
   const worker = new Worker(new URL(import.meta.url), {
     execArgv: [],
     workerData: {
       ownedCommand: true, port: port2, shared, command, args,
+      startupDiagnostic: diagnostic,
       options: {
         cwd: options.cwd === undefined ? process.cwd() : fileURLOrPath(options.cwd),
         env: options.env ?? process.env,
@@ -53,20 +183,29 @@ export function runOwnedCommand(command, args, options = {}) {
   });
   // Errors are delivered asynchronously after this synchronous call returns.
   // Startup and execution progress instead travel through the synchronously polled port.
-  worker.on("error", () => {});
+  worker.on("error", (error) => trace("worker-error-observed", { terminationRequested, error: startupError(error) }));
+  if (diagnostic) {
+    worker.once("exit", (code) => trace("worker-exit-observed", { code, terminationRequested }));
+  }
   worker.unref();
   const started = performance.now();
   let deadline = started + startupMs;
   let running = false;
   let result;
   let firstFailure;
+  let terminalReceipt = false;
+  trace("startup-deadline-armed");
   const receive = (packet) => {
     if (packet?.type === "ready") {
       running = true;
       deadline = performance.now() + timeout + cleanupMs;
+      trace("ready-consumed");
     } else if (packet?.type === "failure") {
       firstFailure ??= packet.error;
+      trace("first-failure-consumed", { error: startupError(firstFailure) });
     } else if (packet?.type === "result") {
+      terminalReceipt = true;
+      trace("terminal-consumed", { result: startupResult(packet.result), readyConsumed: running });
       result = packet.result;
       result.error ??= firstFailure;
     }
@@ -76,14 +215,17 @@ export function runOwnedCommand(command, args, options = {}) {
       receive(receiveMessageOnPort(port1)?.message);
       if (result) break;
       if (performance.now() >= deadline) {
+        trace("parent-deadline-fired", { readyConsumed: running });
         Atomics.store(shared, 1, 1);
         port1.postMessage({ type: "stop" });
+        trace("stop-requested");
         const end = performance.now() + cleanupMs;
         while (performance.now() < end) {
           receive(receiveMessageOnPort(port1)?.message);
           if (result) break;
           Atomics.wait(shared, 0, Atomics.load(shared, 0), 10);
         }
+        trace("late-wait-ended", { terminalReceipt, readyConsumed: running });
         if (!result) {
           // A cached POSIX group number is not retained authority after Worker loss.
           result = emptyResult();
@@ -106,6 +248,8 @@ export function runOwnedCommand(command, args, options = {}) {
     port1.close();
     // Closing the Worker's control socket makes the Windows adapter clean its
     // exact Job independently, including when the Worker itself failed.
+    terminationRequested = true;
+    trace("worker-termination-requested", { terminalReceipt, helperPid: Atomics.load(shared, 3) });
     void worker.terminate().catch(() => {});
     if (process.platform === "win32") {
       const helperPid = Atomics.load(shared, 3);
@@ -118,6 +262,10 @@ export function runOwnedCommand(command, args, options = {}) {
         }
         if (!helperClosed) Atomics.wait(shared, 0, Atomics.load(shared, 0), 10);
       }
+      trace("helper-probe-ended", {
+        helperPid, probeSkipped: helperPid <= 0, reportedAbsent: helperPid > 0 ? helperClosed : null,
+        error: startupError(cleanupCause),
+      });
       if (!helperClosed) {
         result ??= emptyResult();
         result.cleanupError = {
@@ -138,6 +286,8 @@ export function runOwnedCommand(command, args, options = {}) {
     result.error = { ...error, message: `${error.message}; command cleanup was not confirmed` };
   }
   if (result.error) result.error = Object.assign(new Error(result.error.message), result.error);
+  trace("parent-finalized", { result: startupResult(result), terminalReceipt, readyConsumed: running });
+  summarizeStartup(diagnostic);
   return result;
 }
 
@@ -210,6 +360,7 @@ async function supervise({ command, args, options, port, shared }) {
     result.error ??= errorData(error);
     if (failureSent) return;
     failureSent = true;
+    workerTrace("first-failure", { error: startupError(result.error), stdoutBytes: lengths.stdout, stderrBytes: lengths.stderr });
     port.postMessage({ type: "failure", error: {
       code: String(result.error.code ?? "EOWNERFAILURE").slice(0, 64),
       message: String(result.error.message).slice(0, 1024),
@@ -223,7 +374,9 @@ async function supervise({ command, args, options, port, shared }) {
     port.postMessage({ type: "ready" });
     Atomics.add(shared, 0, 1);
     Atomics.notify(shared, 0);
+    workerTrace("ready-forwarded", { childPid: pid });
     timer = setTimeout(() => {
+      workerTrace("execution-deadline-fired");
       fail({ code: "ETIMEDOUT", message: `command timed out after ${options.timeout}ms` });
     }, options.timeout);
     if (Atomics.load(shared, 1)) stop();
@@ -244,6 +397,7 @@ async function supervise({ command, args, options, port, shared }) {
     }
   };
   const onStop = () => {
+    workerTrace("stop-consumed", { done });
     if (!done) fail(Object.assign(new Error("command owner stopped"), { code: "EOWNERCANCELLED" }));
   };
   port.on("message", onStop);
@@ -394,14 +548,18 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
   const completion = new Promise((resolve) => { completionResolve = resolve; });
   const terminateHelper = () => {
     try {
-      helper?.kill();
+      workerTrace("helper-kill-requested", { helperPid: helper?.pid ?? null, helperClosed });
+      const sent = helper?.kill();
+      workerTrace("helper-kill-returned", { sent: sent ?? null });
     } catch (error) {
+      workerTrace("helper-kill-error", { error: startupError(error) });
       recordFailure(error);
     }
   };
   const stop = () => {
     if (stopped) return;
     stopped = true;
+    workerTrace("adapter-stop", { requestIssued, admitted, closedJob, helperClosed, controlEnded });
     clearTimeout(startupTimer);
     if (!requestIssued) {
       // No request means no command Job can exist; retain the helper handle
@@ -411,8 +569,10 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
       socket?.destroy();
     } else {
       socket?.write("STOP\n");
+      workerTrace("helper-stop-write-returned");
     }
     cleanupTimer = setTimeout(() => {
+      workerTrace("cleanup-deadline-fired", { requestIssued, admitted, closedJob, helperClosed, controlEnded });
       missingJobCleanupError = { code: "EOWNERCLEANUP", message: "Windows Job cleanup receipt missing" };
       result.cleanupError ??= missingJobCleanupError;
       recordFailure(result.cleanupError);
@@ -422,11 +582,13 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
       helper?.stderr?.destroy();
       if (!helper || helperClosed) { finish(); return; }
       forcedCloseTimer = setTimeout(() => {
+        workerTrace("forced-close-deadline-fired");
         result.cleanupError = { code: "EOWNERCLEANUP", message: "Windows helper did not close after forced termination" };
         recordFailure(result.cleanupError);
         finish();
       }, cleanupMs);
     }, cleanupMs);
+    workerTrace("cleanup-deadline-armed");
   };
   const finish = () => {
     if (finished) return;
@@ -436,6 +598,7 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
     clearTimeout(forcedCloseTimer);
     socket?.destroy();
     server.close();
+    workerTrace("adapter-finished", { requestIssued, admitted, closedJob, helperClosed, controlEnded });
     completionResolve();
   };
   const maybeFinish = () => {
@@ -463,11 +626,16 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
   server.on("error", (error) => { fail(error); finish(); });
   server.once("connection", (connection) => {
     socket = connection;
+    workerTrace("helper-connected", { stopped });
     server.close();
     let pending = "";
     socket.setEncoding("utf8");
     socket.on("error", fail);
-    socket.on("close", () => { controlEnded = true; maybeFinish(); });
+    socket.on("close", () => {
+      controlEnded = true;
+      workerTrace("control-closed", { admitted, closedJob });
+      maybeFinish();
+    });
     socket.on("data", (data) => {
       pending += data;
       if (pending.length > 8192) {
@@ -480,12 +648,15 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
         pending = pending.slice(end + 1);
         if (/^READY \d+$/.test(line) && !admitted) {
           admitted = true;
+          workerTrace("ready-received", { childPid: Number(line.slice(6)), stopped });
           clearTimeout(startupTimer);
           ready(Number(line.slice(6)));
         } else if (/^EXIT \d+$/.test(line) && admitted) {
           result.status = Number(line.slice(5));
+          workerTrace("exit-received", { status: result.status });
         } else if (line === "CLOSED" && admitted) {
           closedJob = true;
+          workerTrace("job-closed-received");
         } else if (line === "TIMEOUT" && admitted) {
           recordFailure({ code: "ETIMEDOUT", message: `command timed out after ${options.timeout}ms` });
         } else if (line.startsWith("ERROR ")) {
@@ -514,6 +685,7 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
       return;
     }
     try {
+      workerTrace("request-build-begin");
       const executable = resolveWindowsCommand(command, options.cwd, options.env);
       const batch = /\.(cmd|bat)$/i.test(executable);
       const application = batch
@@ -528,6 +700,8 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
           .sort(([a], [b]) => a.toUpperCase().localeCompare(b.toUpperCase()))
           .map(([key, value]) => `${key}=${value}`).join("\0") + "\0\0",
       })}\n`;
+      workerTrace("request-build-end");
+      workerTrace("request-prewrite-check");
       if (stopped || Atomics.load(shared, 1)) {
         stop();
         socket.destroy();
@@ -535,7 +709,10 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
       }
       // A throwing or partial write may still have issued a request.
       requestIssued = true;
-      socket.write(request);
+      const writable = socket.write(request, workerData.startupDiagnostic ? (error) => {
+        workerTrace("request-write-completed", { error: startupError(error) });
+      } : undefined);
+      workerTrace("request-write-returned", { writable });
       if (stopped || Atomics.load(shared, 1)) socket.write("STOP\n");
     } catch (error) { fail(error); socket.destroy(); }
   });
@@ -543,13 +720,19 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
     if (stopped) { finish(); return; }
     const powershell = path.join(environmentValue(options.env, "SYSTEMROOT") ?? process.env.SystemRoot ?? "C:\\Windows",
       "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+    workerTrace("helper-spawn-requested");
     helper = spawn(powershell, [
       "-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
       "-File", fileURLToPath(new URL("./owned-command-windows.ps1", import.meta.url)), pipeName,
+      ...(workerData.startupDiagnostic
+        ? [workerData.startupDiagnostic.directory, workerData.startupDiagnostic.id] : []),
     ], { cwd: options.cwd, env: options.env, windowsHide: true,
       stdio: options.inherit ? "inherit" : ["ignore", "pipe", "pipe"] });
     observe(helper);
-    helper.once("spawn", () => Atomics.store(shared, 3, helper.pid));
+    helper.once("spawn", () => {
+      Atomics.store(shared, 3, helper.pid);
+      workerTrace("helper-spawned", { helperPid: helper.pid });
+    });
     helper.once("error", (error) => { fail(error); finish(); });
     helper.once("close", (code, signal) => {
       Atomics.store(shared, 3, 0);
@@ -557,12 +740,15 @@ function runWindows(command, args, options, result, observe, ready, fail, shared
         helperExitError = { code: "EOWNERNATIVE", message: `Windows adapter failed (${signal ?? code})` };
       }
       helperClosed = true;
+      workerTrace("helper-closed", { code, signal, admitted, closedJob, controlEnded });
       maybeFinish();
     });
   });
   startupTimer = setTimeout(() => {
+    workerTrace("adapter-startup-deadline-fired", { requestIssued, admitted, helperClosed });
     fail(Object.assign(new Error("Windows command adapter startup timed out"), { code: "EOWNERSTART" }));
   }, startupMs);
+  workerTrace("adapter-startup-deadline-armed");
   return { stop, completion };
 }
 
@@ -572,8 +758,10 @@ if (workerData?.ownedCommand === true) {
   try { result = await supervise(workerData); } catch (error) {
     result = { ...emptyResult(), error: errorData(error) };
   }
+  workerTrace("terminal-post-begin", { result: startupResult(result) });
   port.postMessage({ type: "result", result });
   Atomics.add(shared, 0, 1);
   Atomics.notify(shared, 0);
+  workerTrace("terminal-post-returned");
   port.close();
 }


### PR DESCRIPTION
Related: https://github.com/openclaw/crabpot/issues/305

## What Problem This Solves

This is an **experimental, temporary diagnostic draft**, not a Windows startup fix. Issue305 records an unattributed intermittent Windows cold-start failure in the existing process owner. The first Inspector checkout `git init` returned the parent's `EOWNERSTART` with unconfirmed cleanup. No READY was consumed, but native admission and the helper's fate remain unknown.

Original required failure: https://github.com/openclaw/crabpot/actions/runs/34452925787/job/102792576498, source `9b19ec198df5d9ff49e7910ec7c166545e753dc7`, Node24.20.0, Runner2.337.0, Windows Server2025 image `windows-2025-vs2026` version `20260907.229.1`, Git2.55.0.windows.5. Later green observations do not explain that failure.

## Why This Change Was Made

Observe one existing cold-flow CI attempt using independent bounded parent, Worker, PowerShell and native receipt files under `reports/crabpot-startup-305/`. Records distinguish producer progress from consumer receipt, native creation from READY delivery, requested termination from observed callbacks, and diagnostic facts from authoritative cleanup receipts. Later report attempts cannot overwrite the original attempt.

Only three owner files change. The caller, control protocol, cancellation checks, native last-error capture, timeout budgets, cold preparation, serial test order, workflows, dependencies and pins remain unchanged. No new production test API is added.

This instrumentation has an **observer effect**: synchronous file I/O and additional C# compilation can affect startup timing. A near-budget failure needs that limitation considered. File counts, runtime/helper PIDs and missing records are not authority or proof of process extinction.

## User Impact

No repair, release, merge or issue closure is proposed. This draft is limited to one head's automatically attached required and advisory workflows, without standalone repeats.

After that observation: a discriminating failure goes back for repair review; full green establishes a healthy instrumented run only; incomplete receipts establish an instrumentation limit. Issue305 remains open in all three cases until separate disposition.

## Evidence

- Base: `b61d2d9c8750010a0a561bd3e2165eb170689ec5`; diagnostic head: `0f59a816fd5903e40508106848ebe56da3ec9640`.
- Approved patch SHA256: `d99e9fdc2c688a93de6e9035956addfac8bec4fb3f4f2857ebabf332dfead2f1`.
- Fresh scoped P0-P2 review: scoped-clean, no findings, confidence0.93.
- Node24.19.0 local owner checks:10 passed,12 platform skips and one diagnostic import-layout failure. The original import was restored; the unchanged failed procfs case then passed. The original failed log is retained.
- Four focused caller checks passed without importing external Inspector code.
- Disposable copied-owner retention check passed: original startup/cleanup budgets, Worker termination,32-record cap, persisted independent Node receipts, and original failure preserved after a later healthy attempt. This is not native Windows startup proof.
- JavaScript syntax, staged diff and privacy checks passed. PowerShell/C# compilation and native execution are unrun locally because those runtimes are unavailable.
- Required/advisory CI and actual Windows producer traces are pending. Exact Node, Runner, Windows image/version and Git versions will be bound to the resulting observation.

## Fixture Impact

- [ ] Adds or updates fixture manifest entries
- [ ] Updates submodule pins
- [ ] Changes contract or smoke logic
- [ ] Docs only

Diagnostic-only process-owner observation; no fixture behavior change is claimed.

## Fixture Verification

- [ ] `npm test`
- [ ] `node scripts/sync-fixtures.mjs --check`
- [ ] `node scripts/run-contract-smoke.mjs`
- [ ] Strict fixture smoke, if submodules were materialized

The unchanged required CI supplies the cold-flow observation. No local fixture materialization, external fixture imports or repeat CI campaign was performed for this draft.

## Notes

Receipts are bounded to four attempts,32 records per producer and2KiB per record. No environment, command request, argv, raw stack, private path or raw command output is recorded. Existing report upload preserves the diagnostic directory without workflow changes.

## Diagnostic Results (September 10, 2026)

One automatic required/advisory round completed, both attempt 1. Diagnostic head `0f59a816fd5903e40508106848ebe56da3ec9640`, base `b61d2d9c8750010a0a561bd3e2165eb170689ec5`; CI tested synthetic merge `d40e2b43cbfc6f63db28c4e355cb3167460fedd7`, whose tree `5831e3cbe93064217b58c2756c77f3d7b4037d25` matches the diagnostic head.

| Windows observation | Runtime / image | Actual result |
| --- | --- | --- |
| [Required job](https://github.com/openclaw/crabpot/actions/runs/34476116811/job/102867164401) | Node 24.19.0; `windows-2025-vs2026` `20260824.214.3` | Failed suite; no cold-Inspector trace |
| [Advisory job](https://github.com/openclaw/crabpot/actions/runs/34476116944/job/102867425172) | Node 24.20.0; `windows-2025-vs2026` `20260907.229.1` | 398 tests: 390 passed, 0 failed, 8 skipped; all 19 steps completed |

Both used Runner 2.337.0 and Git 2.55.0.windows.5. Required host: `d9b8996498001e04f706255eb0ae818349fd594c`; advisory host: `4aacaa0ee9dd387a23e2bad4747c1377d3a7457f`. Runtime, image and host differences prevent treating these as a controlled comparison.

- **Required:** the raw log flags `behavior eval shell command timeout reports and terminates the command group`, then the unchanged 600,000ms test-step watchdog expires. The exact failed assertion and that command's child fate are unavailable. No `EOWNERSTART` or cold-Inspector receipt was captured. This is an observed distinct failed surface, not an attributed cause or established preexisting defect. The generated summary's `pass` is not the suite status.
- **Advisory:** the `cold-contract-test` trace records helper connection, request read/parse, monitor installation, bootstrap Job assignment, compilation and native creation. Parent READY consumption was +4,148ms and terminal consumption +4,243ms; final status 0, no cleanup error. Native/bootstrap/cancellation/compiler controls also passed. This is a healthy instrumented observation, not a fix or explanation of the original failure.

Producer files are at `crabpot-startup-305/attempt-1/{parent,worker,powershell,native}.jsonl` in each artifact:

- [Required artifact 10152335337](https://github.com/openclaw/crabpot/actions/runs/34476116811/artifacts/10152335337): UUID `eea08263-e59f-4d08-83ea-45c704952323`, explicitly `later-report`, beginning after the failed suite. Its healthy result cannot substitute for the missing cold trace.
- [Advisory artifact 10152391829](https://github.com/openclaw/crabpot/actions/runs/34476116944/artifacts/10152391829): UUID `17075577-7ad0-4889-9007-bbddd08996d0`, `cold-contract-test`.

All eight files have matching per-attempt identities, ordered producer sequences and records within the configured bounds. Synchronous file I/O and added compilation retain an observer effect; diagnostic records do not create cleanup authority. No retry, repair, budget change, merge or closure followed this round. The draft is paused; https://github.com/openclaw/crabpot/issues/305 remains unresolved.

The next scoped investigation is the earlier Windows behavior-eval timeout failure, capturing its full error and child/pipe closure evidence; it is separate from this diagnostic draft.
